### PR TITLE
A rake task to hydrate the db with sample data.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ group :development, :test do
   #gem 'pry-highlight'
   #gem "pry-rescue"
   #gem "pry-stack_explorer"
+  gem 'ffaker'
+  gem 'ruby-progressbar', require: false
   gem "rspec-rails", "~> 2.0"
   gem 'capybara'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       railties (>= 3.0.0)
     fancybox-rails (0.2.1)
       railties (>= 3.1.0)
+    ffaker (1.15.0)
     ffi (1.4.0)
     formtastic (2.2.1)
       actionpack (>= 3.0)
@@ -153,6 +154,7 @@ GEM
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
+    ruby-progressbar (1.0.2)
     rubyzip (0.9.9)
     sass (3.2.6)
     sass-rails (3.2.6)
@@ -206,6 +208,7 @@ DEPENDENCIES
   erubis
   factory_girl_rails (~> 4.0)
   fancybox-rails (~> 0.2.1)
+  ffaker
   formtastic
   haml
   heroku
@@ -218,6 +221,7 @@ DEPENDENCIES
   rails (= 3.2.12)
   redcarpet!
   rspec-rails (~> 2.0)
+  ruby-progressbar
   sass
   sass-rails (~> 3.2.3)
   shoulda

--- a/README.md
+++ b/README.md
@@ -16,10 +16,18 @@ Sessionizer is a tool for managing session registration for unconferences. It wa
 
 ## Running
 
+### Bootstrapping
+
 TBD.
 
 * Create seed data: `rake db:seed`
 
+### Development 
+
+For development, run `rake app:make_believe` to hydrate the database with sample
+data. It will reset the database, create an event, participants, timeslots, 
+sessions, and apply randomized participant interest. This does not run the 
+scheduling algorithm.
 
 ## Deploying
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,6 +2,7 @@ class Room < ActiveRecord::Base
   belongs_to :event
   has_many :sessions, :dependent => :nullify
 
+  # TODO: Deprecate the default scope.
   default_scope :order => 'capacity desc'
 
   validates_numericality_of :capacity, :greater_than => 0, :only_integer => true

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -19,9 +19,10 @@ class Session < ActiveRecord::Base
 
   scope :for_current_event, lambda { {:conditions => {:event_id => Event.current_event.id}} }
 
+  validates_presence_of :description
+  validates_presence_of :event_id
   validates_presence_of :participant_id
   validates_presence_of :title
-  validates_presence_of :description
   validates_length_of :summary, :maximum => 100, :allow_blank => true
   #validates_uniqueness_of :timeslot_id, :scope => :room_id, :allow_blank => true, :message => 'and room combination already in use'
   


### PR DESCRIPTION
Just a little something I need in order to tweak the Sessionizer UX so it does two things I think will be helpful:
1. If you're logged in and you've initially expressed interest, those events will be highlighted.
2. An event attendee can highlight/de-highlight on their device or computer, so over the course of the event, users's won't have to re-find the sessions of interest.
