### PR TITLE
Prefer factory girl shorthand syntax

### DIFF
--- a/spec/controllers/admin/sessions_controller_spec.rb
+++ b/spec/controllers/admin/sessions_controller_spec.rb
@@ -6,11 +6,11 @@ describe Admin::SessionsController do
     ParticipantSession.create(user)
   end
 
-  let(:event) { FactoryGirl.create(:event) }
-  let(:user) { FactoryGirl.create(:participant) }
+  let(:event) { create(:event) }
+  let(:user) { create(:participant) }
 
   context "with an existing session" do
-    let!(:session) { FactoryGirl.create(:session, event: event) }
+    let!(:session) { create(:session, event: event) }
 
     describe "index" do
       it "should set the sessions" do
@@ -39,7 +39,7 @@ describe Admin::SessionsController do
   end
 
   describe "create" do
-    let!(:event) { FactoryGirl.create(:event) }
+    let!(:event) { create(:event) }
     let(:category) { Category.last }
 
     context "with valid values" do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PagesController do
   context "with an event" do
-    let!(:event) { FactoryGirl.create(:event, :full_event) }
+    let!(:event) { create(:event, :full_event) }
 
     it "should show the sessions" do
       get :home

--- a/spec/controllers/presentations_controller_spec.rb
+++ b/spec/controllers/presentations_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe PresentationsController do
-  let(:session) { FactoryGirl.create(:session) }
+  let(:session) { create(:session) }
   describe "#index" do
     it "should be successful" do
       get :index, session_id: session
@@ -13,7 +13,7 @@ describe PresentationsController do
 
   describe "#create" do
     context "when the user exists" do
-      before { FactoryGirl.create(:joe) }
+      before { create(:joe) }
 
       it "should be successful" do
         expect {

--- a/spec/controllers/schedules_controller_spec.rb
+++ b/spec/controllers/schedules_controller_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe SchedulesController do
   describe "#index" do
-    let!(:event) { FactoryGirl.create(:event, :full_event) }
-    let!(:event) { FactoryGirl.create(:event, :full_event) }
+    let!(:event) { create(:event, :full_event) }
+    let!(:event) { create(:event, :full_event) }
     it "should be successful" do
       get :index
       expect(response).to be_successful
@@ -12,14 +12,14 @@ describe SchedulesController do
   end
 
   describe "#ical" do
-    let(:timeslot) { FactoryGirl.create(:timeslot) }
-    let!(:session) { FactoryGirl.create(:session, timeslot: timeslot, event: timeslot.event) }
+    let(:timeslot) { create(:timeslot) }
+    let!(:session) { create(:session, timeslot: timeslot, event: timeslot.event) }
 
     it "should be successful" do
       get :ical
       expect(response).to be_successful
       expect(response.headers['Content-Type']).to eq 'text/calendar; charset=utf-8'
-      expect(response.body).to match /ORGANIZER;CN=Luke Francl:/
+      expect(response.body).to match(/ORGANIZER;CN=Luke Francl:/)
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -6,10 +6,10 @@ describe SessionsController do
     ParticipantSession.create(user)
   end
 
-  let(:user) { FactoryGirl.create(:participant) }
+  let(:user) { create(:participant) }
 
   context "with an existing session" do
-    let(:session) { FactoryGirl.create(:session) }
+    let(:session) { create(:session) }
 
     describe "update" do
       it "should not be updatable by someone who doesn't own it" do
@@ -40,7 +40,7 @@ describe SessionsController do
   end
 
   describe "create" do
-    let!(:event) { FactoryGirl.create(:event) }
+    let!(:event) { create(:event) }
     let(:category) { Category.last }
 
     context "with valid values" do

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -12,8 +12,8 @@ FactoryGirl.define do
       end
 
       after(:create) do |event, evaluator|
-        FactoryGirl.create_list(:room, evaluator.rooms_count, event: event)
-        FactoryGirl.create_list(:timeslot, evaluator.timeslots_count, event: event)
+        create_list(:room, evaluator.rooms_count, event: event)
+        create_list(:timeslot, evaluator.timeslots_count, event: event)
       end
     end
   end

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
 
     title "Stuff about things"
     description "whatever"
-    participant { FactoryGirl.create :luke }
+    participant { create :luke }
     association :event
     association :room
 

--- a/spec/features/display_schedule_spec.rb
+++ b/spec/features/display_schedule_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 feature "Displaying the schedule" do
-  let(:event) { FactoryGirl.create(:event, :full_event) }
+  let(:event) { create(:event, :full_event) }
 
   before do
-    FactoryGirl.create(:session, timeslot: event.timeslots.first, event: event)
+    create(:session, timeslot: event.timeslots.first, event: event)
   end
 
   scenario "should draw the schedule page" do

--- a/spec/helpers/schedules_helper_spec.rb
+++ b/spec/helpers/schedules_helper_spec.rb
@@ -2,14 +2,18 @@ require 'spec_helper'
 
 describe SchedulesHelper do
   describe "#session_columns_for_slot" do
-    let(:timeslot) { FactoryGirl.create(:timeslot) }
+    let(:timeslot) { create(:timeslot) }
     let(:event) { timeslot.event }
-    let(:room) { FactoryGirl.create(:room, event: event) }
-    let(:participant) { FactoryGirl.create(:participant) }
-    let!(:session1) { FactoryGirl.create(:session, room: room, timeslot: timeslot, event: event, participant: participant) }
-    let!(:session2) { FactoryGirl.create(:session, room: room, timeslot: timeslot, event: event, participant: participant) }
-    let!(:session3) { FactoryGirl.create(:session, room: room, timeslot: timeslot, event: event, participant: participant) }
-    let!(:session4) { FactoryGirl.create(:session, room: room, timeslot: timeslot, event: event, participant: participant) }
+    let(:room) { create(:room, event: event) }
+    let(:participant) { create(:participant) }
+    let!(:session1) { create_session }
+    let!(:session2) { create_session }
+    let!(:session3) { create_session }
+    let!(:session4) { create_session }
+
+    def create_session
+      create(:session, room: room, timeslot: timeslot, event: event, participant: participant) 
+    end
 
     it "should arange the sessions into two groups" do
       yielded = []

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,11 +10,9 @@ describe Event do
   it { should have_many :rooms }
 
   context "creating a new event" do
-    before { FactoryGirl.create(:event, date: 2.months.ago) }
+    before { create(:event, date: 2.months.ago) }
     it "should clear the existing current_event" do
-      expect {
-        e2 = FactoryGirl.create(:event)
-      }.to change { Event.current_event }
+      expect { create(:event) }.to change { Event.current_event }
     end
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Room do
-  subject { FactoryGirl.create(:event).rooms.create!(:name => 'Asdf', :capacity => 100) }
+  subject { create(:event).rooms.create!(:name => 'Asdf', :capacity => 100) }
   it { should have_many :sessions }
   it { should belong_to :event }
 


### PR DESCRIPTION
I prefer to use the factory girl shorthand notation when
creating factory girl objects. It saves us typing 12 characters 
each time. What do you think? 
