### PR TITLE
Move primary nav around to include a link to the sessionizer root path.

### DIFF
--- a/src/app/assets/stylesheets/shared.css.scss
+++ b/src/app/assets/stylesheets/shared.css.scss
@@ -222,6 +222,11 @@ ul#menu {
       }
     }
   }
+
+  li.bar, li.demo {
+    float:right;
+  }
+
   .last {
     margin-right: 0;
   }

--- a/src/app/views/layouts/application.html.erb
+++ b/src/app/views/layouts/application.html.erb
@@ -13,11 +13,27 @@
     <div class="full-column">
       <div class="center-column">
         <ul id="menu">
-          <li class="star"><a href="http://minnestar.org/" ><span class="description">the community of</span><br />minne<span class="star">✱</span></a></li>
-          <li class="bar"><a href="http://minnestar.org/minnebar/"><span class="description">(un)conference</span><br />minne<span class="bar">bar</span></a></li>
-          <li class="demo"><a href="http://minnestar.org/minnedemo/"><span class="description">geek show &amp; tell</span><br />minne<span class="demo">demo</span></a></li>
+          <li class="star">
+            <a href="/" >
+              <span class="description">sessionizer home</span><br />
+                minne<span class="star">✱</span>
+            </a>
+          </li>
+          <li class="demo">
+            <a href="http://minnestar.org/minnedemo/">
+              <span class="description">geek show &amp; tell</span><br />minne<span class="demo">demo</span>
+            </a>
+          </li>
+
+          <li class="bar">
+            <a href="http://minnestar.org/minnebar/">
+              <span class="description">(un)conference</span><br />
+              minne<span class="bar">bar</span>
+            </a>
+          </li>
         </ul>
-        <div class="clearboth"><!-- --></div>
+        <div class="clearboth"></div>
+
       </div><!-- / center-column -->
     </div><!-- / full-column -->
 


### PR DESCRIPTION
We currently don't have any way to get back to the landing page in the app. And clicking on the upper-left most icon takes you off the site. 
BEFORE: 
![2015-04-02 at 4 45 pm](https://cloud.githubusercontent.com/assets/12005/6974382/e385f8ae-d957-11e4-8e9a-f443a3f27e27.png)


We moved the bar/demo icons to the right and made the first star icon a 'go to home' link. 
AFTER: 
![2015-04-02 at 4 47 pm](https://cloud.githubusercontent.com/assets/12005/6974394/0c0db3ca-d958-11e4-8654-54e1cda5bf3d.png)

