### PR TITLE
.rvmrc file unneeded & specifies wrong version

### DIFF
--- a/src/.rvmrc
+++ b/src/.rvmrc
@@ -1,1 +1,0 @@
-rvm 1.9.3@sessionizer --create


### PR DESCRIPTION
This is defunct, right?