### PR TITLE
Sanitize markdown

### DIFF
--- a/src/app/assets/stylesheets/shared.css.scss
+++ b/src/app/assets/stylesheets/shared.css.scss
@@ -426,6 +426,9 @@ hr {
   border-radius: 10px;
   border: 1px solid #e8e8e8;
   margin-bottom: 20px;
+  img {
+    max-width: 100%;
+  }
 }
 
 .left  { float:left; }

--- a/src/app/helpers/application_helper.rb
+++ b/src/app/helpers/application_helper.rb
@@ -11,7 +11,11 @@ module ApplicationHelper
     return '' unless str
     @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML,
         :autolink => true, :space_after_headers => true)
-    @markdown.render(str).html_safe
+    close_tags(@markdown.render(str)).html_safe
+  end
+
+  def close_tags(html)
+    Nokogiri::HTML::DocumentFragment.parse(html).to_html
   end
 
   def add_sessions_button

--- a/src/app/helpers/application_helper.rb
+++ b/src/app/helpers/application_helper.rb
@@ -9,13 +9,21 @@ module ApplicationHelper
 
   def markdown(str)
     return '' unless str
-    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML,
-        :autolink => true, :space_after_headers => true)
-    close_tags(@markdown.render(str)).html_safe
+    @markdown ||= Redcarpet::Markdown.new(
+        Redcarpet::Render::HTML.new,
+        autolink: true,
+        space_after_headers: true)
+    sanitize_html(close_tags(@markdown.render(str))).html_safe
   end
 
   def close_tags(html)
     Nokogiri::HTML::DocumentFragment.parse(html).to_html
+  end
+
+  def sanitize_html(html)
+    sanitize html,
+      tags: %w(a img b i em strong p br ul ol li),
+      attributes: %w(href src height width alt)
   end
 
   def add_sessions_button

--- a/src/spec/helpers/application_helper_spec.rb
+++ b/src/spec/helpers/application_helper_spec.rb
@@ -5,6 +5,7 @@ describe ApplicationHelper do
     def normalize_space(string)
       string.
         gsub(/\s+/, ' ').        # Don't care how many spaces or what kind
+        gsub('<p></p>', ' ').    # Markdown likes to do this sometimes
         gsub(/^ +| +$/, '').     # Ignore space at beginning & end
         gsub(/> +</, '><')       # Ignore space around tags
     end
@@ -29,6 +30,38 @@ describe ApplicationHelper do
       expect(helper.markdown("foo <strong bar")).
         to eq_ignoring_space "<p>foo &lt;strong bar</p>"
     end
+
+    it 'allows some limited html formatting' do
+      html = '<p>foo <i>bar</i> and <b>baz</b><br>So <strong>there!</strong></p><ul><li>foo</li></ul>'
+      expect(helper.markdown(html)).
+        to eq_ignoring_space html
+    end
+
+    it 'allows links' do
+      expect(helper.markdown('foo <a href="http://bar.com">bar</a> baz')).
+        to eq_ignoring_space '<p>foo <a href="http://bar.com">bar</a> baz</p>'
+    end
+
+    it 'limits link attributes' do
+      expect(helper.markdown('foo <a href="http://bar.com" target="_blank" onclick="alert(1)" style="font-size: 200%" class="huge">bar</a> baz')).
+        to eq_ignoring_space '<p>foo <a href="http://bar.com">bar</a> baz</p>'
+    end
+
+    it 'allows img tags' do
+      expect(helper.markdown('foo <img src="http://bar.com"> bar')).
+        to eq_ignoring_space '<p>foo <img src="http://bar.com"> bar</p>'
+    end
+
+    it 'limits img tag attributes' do
+      expect(helper.markdown('foo <img src="http://bar.com" width=100 style="border: 2px solid red" height=200 border=7 alt="bar"> bar')).
+        to eq_ignoring_space '<p>foo <img src="http://bar.com" width="100" height="200" alt="bar"> bar</p>'
+    end
+
+    {iframe: true, script: false, nonstandard: true}.each do |tag, preserve_nested|
+      it "strips <#{tag}> tags" do
+        expect(helper.markdown("foo <#{tag}>bar</#{tag}> baz")).
+          to eq_ignoring_space "<p>foo #{'bar' if preserve_nested} baz</p>"
+      end
+    end
   end
 end
-

--- a/src/spec/helpers/application_helper_spec.rb
+++ b/src/spec/helpers/application_helper_spec.rb
@@ -19,6 +19,16 @@ describe ApplicationHelper do
       expect(helper.markdown("foo\n\n* bar\n* baz")).
         to eq_ignoring_space "<p>foo</p><ul><li>bar</li><li>baz</li></ul>"
     end
+
+    it 'closes tags' do
+      expect(helper.markdown("<strong>foo\n\nbar <i>baz")).
+        to eq_ignoring_space "<p><strong>foo</strong></p><p>bar <i>baz</i></p>"
+    end
+
+    it 'sanitizes malformed tags' do
+      expect(helper.markdown("foo <strong bar")).
+        to eq_ignoring_space "<p>foo &lt;strong bar</p>"
+    end
   end
 end
 

--- a/src/spec/helpers/application_helper_spec.rb
+++ b/src/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe ApplicationHelper do
+  RSpec::Matchers.define :eq_ignoring_space do |expected|
+    def normalize_space(string)
+      string.
+        gsub(/\s+/, ' ').        # Don't care how many spaces or what kind
+        gsub(/^ +| +$/, '').     # Ignore space at beginning & end
+        gsub(/> +</, '><')       # Ignore space around tags
+    end
+
+    match do |actual|
+      normalize_space(actual) == normalize_space(expected)
+    end
+  end
+
+  describe "#markdown" do
+    it 'converts markdown to html' do
+      expect(helper.markdown("foo\n\n* bar\n* baz")).
+        to eq_ignoring_space "<p>foo</p><ul><li>bar</li><li>baz</li></ul>"
+    end
+  end
+end
+


### PR DESCRIPTION
Prevents session descriptions & user bios from being able to clobber the rest of the page. (We currently have a couple of bios that are doing that with unclosed tags and bad style attributes.)

Also, although I haven’t investigated, the lack of sanitizing is probably a security risk.

I was a little concerned about the performance cost of this aggressive sanitizing on the schedule page, which invisibly renders all the session descs & bios in one huge blob, but some quick tests suggest it adds negligible time.

Fixes #70.