### PR TITLE
Restore Event JSON export

### DIFF
--- a/src/app/controllers/events_controller.rb
+++ b/src/app/controllers/events_controller.rb
@@ -1,0 +1,11 @@
+class EventsController < ApplicationController
+  def show
+    @event = Event.includes(:sessions).find(params[:id])
+
+    respond_to do |format|
+      format.json do
+        render json: @event.to_json(include: { sessions: { methods: [:starts_at, :room_name, :presenter_names] } })
+      end
+    end
+  end
+end

--- a/src/app/models/session.rb
+++ b/src/app/models/session.rb
@@ -13,9 +13,9 @@ class Session < ActiveRecord::Base
   has_many :attendances, :dependent => :destroy
   has_many :participants, :through => :attendances
 
-  delegate :name, :to => :room, :prefix => true
-  delegate :starts_at, :to => :timeslot
-  delegate :name, :to => :level, :prefix => true, :allow_nil => true
+  delegate :name, to: :room, prefix: true, allow_nil: true
+  delegate :starts_at, to: :timeslot, allow_nil: true
+  delegate :name, to: :level, prefix: true, allow_nil: true
 
   scope :with_attendence_count, :select => '*', :joins => "LEFT OUTER JOIN (SELECT session_id, count(id) AS attendence_count FROM attendances GROUP BY session_id) AS attendence_aggregation ON attendence_aggregation.session_id = sessions.id"
 

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -15,11 +15,12 @@ Sessionizer::Application.routes.draw do
 
   resources :participants, :except => [:destroy]
   resources :categories, only: :show
+  resources :events, only: :show
 
   match '/login' => 'user_sessions#new', :as => :new_login, :via => 'get'
   match '/login' => 'user_sessions#create', :as => :login, :via => 'post'
   match '/logout' => 'user_sessions#destroy', :as => :logout, :via => 'delete'
-  
+
   resources :password_resets, :only => [ :new, :create, :edit, :update ]
 
   #something is still off here

--- a/src/spec/controllers/events_controller_spec.rb
+++ b/src/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe EventsController do
+  let(:event) { FactoryGirl.create(:event) }
+
+  context 'show' do
+    context 'in JSON format' do
+      it 'is successful' do
+        get :show, id: event, format: :json
+        expect(response).to be_success
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+  end
+end


### PR DESCRIPTION
EventsController was removed in 432a205c608d8621996ea2a7ed7991f51317bc13 due to being unused. Turns out that wasn't quite true.

Should _actually_ fix #75.