### PR TITLE
Allow unschedulable sessions

### DIFF
--- a/src/lib/scheduling/context.rb
+++ b/src/lib/scheduling/context.rb
@@ -1,5 +1,5 @@
 module Scheduling
-  
+
   # ActiveModel access is slow enough that we create a stripped-down, in-memory version of the various
   # models we need to create a schedule, then run the annealer against this in-memory model.
   # This class sucks all the rooms, sessions and timeslots from the DB, and provides them during annealing.
@@ -8,11 +8,11 @@ module Scheduling
   # The Schedule class contains all the state we're trying to optimize.
   #
   class Context
-    
+
     attr_reader :sessions, :timeslots, :rooms
-  
+
     def initialize(event)
-      @sessions = event.session_ids
+      @sessions = event.sessions.where(timeslot: nil).select(:id).map(&:id)
       @timeslots = event.timeslots.where(schedulable: true)
       @rooms = event.rooms
       @people_by_id = Hash.new { |h,id| h[id] = Person.new(self, id) }
@@ -22,9 +22,9 @@ module Scheduling
 
       report_count :attending
       report_count :presenting
-      
+
       raise 'No session-presenter relationships in DB. Did you populate the presentations table?' unless people.size > 0
-      
+
       event.presenter_timeslot_restrictions.each do |restriction|
         person(restriction.participant_id).
           assign_timeslot_penalty(restriction.timeslot_id, restriction.weight)
@@ -36,11 +36,13 @@ module Scheduling
     end
 
   private
-    
+
     def person(id)
       @people_by_id[id]
     end
-    
+
+    # @param [Symbol] role
+    # @param [Class] either Attendance or Presentation
     def load_sets(role, association_model)
       # This brute force iteration is hardly slick, but I'm too rusty on fancy ActiveRecord querying to care just now. -PPC
       size = association_model.where(session_id: @sessions).select(:participant_id, :session_id).each do |assoc|
@@ -55,6 +57,6 @@ module Scheduling
       person_count = people.count { |p| p.send(role).size > 0 }
       puts "#{assoc_count} #{role.to_s.humanize.downcase} relationships" +
            " (#{person_count} people, avg #{"%1.1f" % (assoc_count / person_count.to_f)} each)"
-    end   
+    end
   end
 end

--- a/src/lib/scheduling/context.rb
+++ b/src/lib/scheduling/context.rb
@@ -12,7 +12,7 @@ module Scheduling
     attr_reader :sessions, :timeslots, :rooms
 
     def initialize(event)
-      @sessions = event.sessions.where(timeslot: nil).select(:id).map(&:id)
+      @sessions = event.sessions.where(timeslot: nil).pluck(:id)
       @timeslots = event.timeslots.where(schedulable: true)
       @rooms = event.rooms
       @people_by_id = Hash.new { |h,id| h[id] = Person.new(self, id) }

--- a/src/lib/tasks/app.rake
+++ b/src/lib/tasks/app.rake
@@ -134,8 +134,15 @@ namespace :app do
 
   desc 'clear the current schedule (DANGER: Irreversible!!!). You must do the before generating a new schedule'
   task clear_schedule: :environment do
-    event = Event.current_event
-    event.sessions.each { |s| s.update(timeslot_id: nil) }
+    STDOUT.puts "Are you sure? This destroys the existing schedule and you will not be\n" \
+      "able to retrieve it. You should back up the database before doing this.\n\nIf you are really sure, type \"SCHEDULE ARMAGEDDON\" now (anything else to cancel)..."
+    input = STDIN.gets.strip
+    if input == 'SCHEDULE ARMAGEDDON'
+      Event.current_event.sessions.update_all(timeslot_id: nil)
+      STDOUT.puts "\nThe current schedule has been erased."
+    else
+      STDOUT.puts "\nNo changes made."
+    end
   end
 
   # We can schedule certain sessions into blocks before running


### PR DESCRIPTION
Sessions that are entered before the scheduler are run are now
immutable with regards to their timeslot. They will not get scheduled
elsewhere.  This enable you to add sessions that have to be in a
certain place at a certain time. The scheduler pays no-attention to them,
so you only want to place them into Timeslots where schedulable is
false.  For example you may place a "Presenters Luncheon, rm 123"
during the  "Lunch" timeslot.

Also added a rake task `app:clear_schedule` This enables the generated
schedule to be cleared so an alternate schedule can be generated.