### PR TITLE
Use Rails caching for current_event

### DIFF
--- a/src/app/models/event.rb
+++ b/src/app/models/event.rb
@@ -11,22 +11,7 @@ class Event < ActiveRecord::Base
 
   validates_presence_of :name, :date
 
-  after_create :reset_current
-
-
   def self.current_event(opts = {})
-    @current_event ||= begin
-                         rel = Event.order(:date)
-                         rel = rel.includes(opts[:include]) if opts[:include]
-                         rel.last
-                       end
-  end
-
-  def self.reset_current!
-    @current_event = nil
-  end
-
-  def reset_current
-    self.class.reset_current!
+    Event.order(:date).last
   end
 end

--- a/src/spec/controllers/schedules_controller_spec.rb
+++ b/src/spec/controllers/schedules_controller_spec.rb
@@ -2,21 +2,33 @@ require 'spec_helper'
 
 describe SchedulesController do
   describe "#index" do
+    before { Rails.cache.clear }
     context "when settings says to show schedules" do
       before { allow(Settings).to receive(:show_schedule?).and_return(true) }
       let!(:event) { create(:event, :full_event) }
-      let!(:event) { create(:event, :full_event) }
-      it "should be successful" do
+      it "is successful" do
+        expect(controller).to receive(:event).with(true).and_call_original
         get :index
         expect(response).to be_successful
         expect(assigns[:event]).to eq event
       end
     end
+
     context "when schedules are not yet displayed" do
       before { allow(Settings).to receive(:show_schedule?).and_return(false) }
-      it "should redirect" do
+      it "redirects" do
         get :index
         expect(response).to redirect_to home_page_path
+      end
+    end
+
+    context "when schedules are not yet displayed, but they really want to see it anyway" do
+      let!(:event) { create(:event, :full_event) }
+      it "is successful" do
+        expect(controller).to receive(:event).with(false).and_call_original
+        get :index, force: true
+        expect(response).to be_successful
+        expect(assigns[:event]).to eq event
       end
     end
   end
@@ -25,7 +37,7 @@ describe SchedulesController do
     let(:timeslot) { create(:timeslot) }
     let!(:session) { create(:session, timeslot: timeslot, event: timeslot.event) }
 
-    it "should be successful" do
+    it "is successful" do
       get :ical
       expect(response).to be_successful
       expect(response.headers['Content-Type']).to eq 'text/calendar; charset=utf-8'


### PR DESCRIPTION
Move the caching of current_event and schedule into the controller layer
This allows you to use a cache and have all processes return the same
values (unless you're using memory store).