### PR TITLE
Allow rooms to be schedulable

### DIFF
--- a/src/db/migrate/20150920192518_add_schedulable_to_room.rb
+++ b/src/db/migrate/20150920192518_add_schedulable_to_room.rb
@@ -1,0 +1,5 @@
+class AddSchedulableToRoom < ActiveRecord::Migration
+  def change
+    add_column :rooms, :schedulable, :boolean, default: true
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150911192254) do
+ActiveRecord::Schema.define(version: 20150920192518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,11 +83,12 @@ ActiveRecord::Schema.define(version: 20150911192254) do
   add_index "presenter_timeslot_restrictions", ["timeslot_id", "participant_id"], name: "present_timeslot_participant_unique", unique: true, using: :btree
 
   create_table "rooms", force: :cascade do |t|
-    t.integer  "event_id",   null: false
-    t.string   "name",       null: false
+    t.integer  "event_id",                   null: false
+    t.string   "name",                       null: false
     t.integer  "capacity"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "schedulable", default: true
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/src/lib/scheduling/context.rb
+++ b/src/lib/scheduling/context.rb
@@ -1,5 +1,4 @@
 module Scheduling
-
   # ActiveModel access is slow enough that we create a stripped-down, in-memory version of the various
   # models we need to create a schedule, then run the annealer against this in-memory model.
   # This class sucks all the rooms, sessions and timeslots from the DB, and provides them during annealing.
@@ -8,13 +7,12 @@ module Scheduling
   # The Schedule class contains all the state we're trying to optimize.
   #
   class Context
-
     attr_reader :sessions, :timeslots, :rooms
 
     def initialize(event)
       @sessions = event.sessions.where(timeslot: nil).pluck(:id)
       @timeslots = event.timeslots.where(schedulable: true)
-      @rooms = event.rooms
+      @rooms = event.rooms.where(schedulable: true)
       @people_by_id = Hash.new { |h,id| h[id] = Person.new(self, id) }
 
       load_sets :attending,  Attendance


### PR DESCRIPTION
Unschedulable rooms can be used for events on the schedule but that you
don't want to be automatically scheduled by the annealer.  For example,
we could add the cafeteria as a room, but we don't want to schedule
sessions there.  We could "hard code" an event (i.e. BOF meetup) to happen
in the cafeteria though.