### PR TITLE
Feature/make vagrant ansible great again

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,26 @@
+
+To support Brad's mobile app
+
+
+ADD to participants
+* twitter handle
+* github id 
+* IMAGE?
+
+JSON response for participants
+* Add bio, email, everything... 
+
+
+Add room endpoint
+Add timeslot end point
+
+UPDATE Sessions to include timeslot information
+
+Add talk information to talk (github references, etc)
+
+
+Add extra presenters to sessions (if the session has multiple
+presenters)  (in json response)
+
+
+

--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -1,38 +1,16 @@
-# PostgreSQL. Versions 7.4 and 8.x are supported.
-#
-# Install the ruby-postgres driver:
-#   gem install ruby-postgres
-# On Mac OS X:
-#   gem install ruby-postgres -- --include=/usr/local/pgsql
-# On Windows:
-#   gem install ruby-postgres
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: 5
+  username: vagrant
+  password: 
+
 development:
-  adapter: postgresql
-  encoding: unicode
+  <<: *default
   database: sessionizer_development
-  pool: 5
-  username: vagrant
-  password:
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
-  encoding: unicode
+  <<: *default
   database: sessionizer_test
-  pool: 5
-  username: vagrant
-  password:
-
-production:
-  adapter: postgresql
-  encoding: unicode
-  database: sessionizer_test
-  pool: 5
-  username: vagrant
-  password:
-
-

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20150920192518) do
   add_index "attendances", ["session_id", "participant_id"], name: "index_attendances_on_session_id_and_participant_id", unique: true, using: :btree
 
   create_table "categories", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
   end
 
   add_index "categories", ["name"], name: "index_categories_on_name", unique: true, using: :btree
@@ -41,25 +41,25 @@ ActiveRecord::Schema.define(version: 20150920192518) do
   add_index "categorizations", ["category_id", "session_id"], name: "index_categorizations_on_category_id_and_session_id", unique: true, using: :btree
 
   create_table "events", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.date     "date",       null: false
+    t.string   "name",       limit: 255, null: false
+    t.date     "date",                   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "levels", force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 255
   end
 
   create_table "participants", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
+    t.string   "name",              limit: 255
+    t.string   "email",             limit: 255
     t.text     "bio"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "crypted_password"
-    t.string   "persistence_token"
-    t.string   "perishable_token",  default: "", null: false
+    t.string   "crypted_password",  limit: 255
+    t.string   "persistence_token", limit: 255
+    t.string   "perishable_token",  limit: 255, default: "", null: false
   end
 
   add_index "participants", ["email"], name: "index_participants_on_email", unique: true, using: :btree
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 20150920192518) do
   add_index "presenter_timeslot_restrictions", ["timeslot_id", "participant_id"], name: "present_timeslot_participant_unique", unique: true, using: :btree
 
   create_table "rooms", force: :cascade do |t|
-    t.integer  "event_id",                   null: false
-    t.string   "name",                       null: false
+    t.integer  "event_id",               null: false
+    t.string   "name",       limit: 255, null: false
     t.integer  "capacity"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -92,17 +92,17 @@ ActiveRecord::Schema.define(version: 20150920192518) do
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.integer  "participant_id",                 null: false
-    t.string   "title",                          null: false
-    t.text     "description",                    null: false
-    t.boolean  "panel",          default: false, null: false
-    t.boolean  "projector",      default: false, null: false
+    t.integer  "participant_id",                             null: false
+    t.string   "title",          limit: 255,                 null: false
+    t.text     "description",                                null: false
+    t.boolean  "panel",                      default: false, null: false
+    t.boolean  "projector",                  default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "event_id"
     t.integer  "timeslot_id"
     t.integer  "room_id"
-    t.string   "summary"
+    t.string   "summary",        limit: 255
     t.integer  "level_id"
   end
 
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 20150920192518) do
   add_index "settings", ["current_event_id"], name: "index_settings_on_current_event_id", using: :btree
 
   create_table "timeslots", force: :cascade do |t|
-    t.integer  "event_id",                   null: false
+    t.integer  "event_id",   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "starts_at"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.100.180", name: APP_NAME
+  config.vm.network "private_network", ip: "192.168.100.185", name: APP_NAME
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/vagrant/ansible/development.yml
+++ b/vagrant/ansible/development.yml
@@ -92,21 +92,21 @@
   tasks:
     - local_action:
         module: stat
-        path: ../../src/config/database.yml
+        path: ../src/config/database.yml
       register: database_yml
     - local_action:
         module: template
-        src: templates/database.yml.j2/
-        dest: ../../src/config/database.yml
+        src: templates/database.yml.j2
+        dest: ../src/config/database.yml
       when: not database_yml.stat.exists
     - local_action:
         module: stat
-        path: ../../src/config/secrets.yml
+        path: ../src/config/secrets.yml
       register: secrets_yml
     - local_action:
         module: template
         src: templates/secrets.yml.j2
-        dest: ../../src/config/secrets.yml
+        dest: ../src/config/secrets.yml
       when: not secrets_yml.stat.exists
     - command: bundle install chdir=/srv/{{app_name}}/
     - command: bundle exec rake db:create chdir=/srv/{{app_name}}/


### PR DESCRIPTION
Vagrant / ansible playbooks had syntax errors in them for some reason. A fresh `vagrant up` or `vagrant provision` now works again. 