### PR TITLE
Random session order

### DIFF
--- a/src/app/assets/stylesheets/shared.css.scss
+++ b/src/app/assets/stylesheets/shared.css.scss
@@ -138,6 +138,7 @@ ul.sessionsList {
     padding-left: 1.8em;
     letter-spacing: -0.05em;
     display: inline-block;  // prevent column break
+    width: 100%;
     a {
       &:link, &:visited {
         font: 700 1.2em / 1.2em;

--- a/src/app/assets/stylesheets/shared.css.scss
+++ b/src/app/assets/stylesheets/shared.css.scss
@@ -2,6 +2,15 @@ $white: #fff;
 $grey: rgb(209, 217, 220);
 $minnebar-purple: #414D87;
 
+@mixin columns($width, $gap) {
+  column-width: $width;
+  column-gap: $gap;
+  -moz-column-width: $width;
+  -moz-column-gap: $gap;
+  -webkit-column-width: $width;
+  -webkit-column-gap: $gap;
+}
+
 body {
   background-color: #fff;
   font-family: 'Helvetica Neue', Verdana, Helvetica, sans-serif;
@@ -120,13 +129,15 @@ ul.sessionsList {
   margin: 0;
   padding: 0;
   list-style-type: none;
+  @include columns(24em, 1em);
   li.attending {
     background: image-url("minnebar.png") no-repeat 0 .1em;
   }
   li {
-    margin: 16px 0;
+    margin: 0.6em 0;
     padding-left: 1.8em;
     letter-spacing: -0.05em;
+    display: inline-block;  // prevent column break
     a {
       &:link, &:visited {
         font: 700 1.2em / 1.2em;

--- a/src/app/controllers/pages_controller.rb
+++ b/src/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   def home
     @current_event = Event.current_event
-    @recent_sessions = @current_event ? @current_event.sessions.limit(10).order('created_at desc') : []
+    @recent_sessions = @current_event ? @current_event.sessions.limit(10).random_order : []
 
     @categories = Category.all.order('id')
   end

--- a/src/app/controllers/pages_controller.rb
+++ b/src/app/controllers/pages_controller.rb
@@ -1,7 +1,8 @@
 class PagesController < ApplicationController
   def home
     @current_event = Event.current_event
-    @recent_sessions = @current_event ? @current_event.sessions.limit(10).random_order : []
+    @recent_sessions = @current_event ? @current_event.sessions.limit(4).recent : []
+    @random_sessions = @current_event ? @current_event.sessions.limit(6).random_order : []
 
     @categories = Category.all.order('id')
   end

--- a/src/app/controllers/sessions_controller.rb
+++ b/src/app/controllers/sessions_controller.rb
@@ -33,7 +33,7 @@ class SessionsController < ApplicationController
     else
       @event = Event.current_event
     end
-    @sessions = @event.sessions
+    @sessions = @event.sessions.order('created_at desc')
     respond_with @sessions do |format|
       format.json {
         render json: SessionsJsonBuilder.new.to_json(@sessions.uniq.flatten)

--- a/src/app/models/session.rb
+++ b/src/app/models/session.rb
@@ -21,7 +21,9 @@ class Session < ActiveRecord::Base
 
   scope :for_current_event, -> { where(event_id: Event.current_event.id) }
 
-  scope :random_order, -> { order('random()') }  # Slow, but fast enough when only ~100 rows
+  scope :recent, -> { order('created_at desc') }
+  
+  scope :random_order, -> { order('random()') }
 
   validates_presence_of :description
   validates_presence_of :event_id

--- a/src/app/models/session.rb
+++ b/src/app/models/session.rb
@@ -19,7 +19,9 @@ class Session < ActiveRecord::Base
 
   scope :with_attendence_count, -> { select('*').joins("LEFT OUTER JOIN (SELECT session_id, count(id) AS attendence_count FROM attendances GROUP BY session_id) AS attendence_aggregation ON attendence_aggregation.session_id = sessions.id") }
 
-  scope :for_current_event, lambda { where(event_id: Event.current_event.id) }
+  scope :for_current_event, -> { where(event_id: Event.current_event.id) }
+
+  scope :random_order, -> { order('random()') }  # Slow, but fast enough when only ~100 rows
 
   validates_presence_of :description
   validates_presence_of :event_id

--- a/src/app/views/pages/_category_grid.html.erb
+++ b/src/app/views/pages/_category_grid.html.erb
@@ -1,7 +1,7 @@
       <div class="column grid_<%= grid %>">
         <h3>Sessions about <%= category.name %></h3>
         <ul class="sessionsList">
-          <%= render category.sessions.for_current_event.limit(5) %>
+          <%= render category.sessions.for_current_event.random_order.limit(5) %>
         </ul>
         <p><%= link_to 'See more...', category_path(category) %></p>
       </div>

--- a/src/app/views/pages/_category_grid.html.erb
+++ b/src/app/views/pages/_category_grid.html.erb
@@ -3,6 +3,6 @@
         <ul class="sessionsList">
           <%= render category.sessions.for_current_event.random_order.limit(5) %>
         </ul>
-        <p><%= link_to 'See more...', category_path(category) %></p>
+        <p class="more_sessions"><%= link_to 'See more...', category_path(category) %></p>
       </div>
 

--- a/src/app/views/pages/_sessions.html.erb
+++ b/src/app/views/pages/_sessions.html.erb
@@ -1,4 +1,4 @@
-    <h2>Recently Added Sessions</h2>
+    <h2>A Sampling of Sessions</h2>
     <ul class="sessionsList">
       <%= render @recent_sessions %>
     </ul>

--- a/src/app/views/pages/_sessions.html.erb
+++ b/src/app/views/pages/_sessions.html.erb
@@ -1,3 +1,5 @@
+  <%= cache Session.maximum(:updated_at), expires_in: 20.seconds do %>
+
     <h2>A Sampling of Sessions</h2>
     <ul class="sessionsList">
       <%= render @recent_sessions %>
@@ -21,4 +23,5 @@
    <div class="row">
      <p><%= add_sessions_button %></p>
    </div>
-
+  
+  <% end %>

--- a/src/app/views/pages/_sessions.html.erb
+++ b/src/app/views/pages/_sessions.html.erb
@@ -2,10 +2,16 @@
 
     <h2>A Sampling of Sessions</h2>
     <ul class="sessionsList">
+      <%= render @random_sessions %>
+    </ul>
+    <p class="more_sessions"><%= link_to 'See all sessions', sessions_path %></p>
+
+    <h2>Recently Added</h2>
+    <ul class="sessionsList">
       <%= render @recent_sessions %>
     </ul>
-
     <p class="more_sessions"><%= link_to 'See all sessions', sessions_path %></p>
+    
     <div class="row">
       <%= render 'category_grid', category: @categories.first, grid: 3 %>
       <%= render 'category_grid', category: @categories.second, grid: 3 %>

--- a/src/app/views/sessions/index.html.erb
+++ b/src/app/views/sessions/index.html.erb
@@ -2,7 +2,7 @@
 (most recently added first)
 <div class="row">
   <p><%= add_sessions_button %></p>
-  <div class="column grid_6" style="margin-left:0px">
+  <div class="column grid_10" style="margin-left:0px">
     <ul class="sessionsList">
       <%= render @sessions %>
     </ul>

--- a/src/app/views/sessions/index.html.erb
+++ b/src/app/views/sessions/index.html.erb
@@ -1,4 +1,5 @@
 <% title('All Sessions') %>
+(most recently added first)
 <div class="row">
   <p><%= add_sessions_button %></p>
   <div class="column grid_6" style="margin-left:0px">

--- a/src/app/views/sessions/index.html.erb
+++ b/src/app/views/sessions/index.html.erb
@@ -1,11 +1,13 @@
 <% title('All Sessions') %>
 (most recently added first)
-<div class="row">
-  <p><%= add_sessions_button %></p>
-  <div class="column grid_10" style="margin-left:0px">
-    <ul class="sessionsList">
-      <%= render @sessions %>
-    </ul>
-  </div>
-</div>
 
+<% cache [Session.maximum(:updated_at), current_participant] do %>
+  <div class="row">
+    <p><%= add_sessions_button %></p>
+    <div class="column grid_10" style="margin-left:0px">
+      <ul class="sessionsList">
+        <%= render @sessions %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/src/spec/features/interest_gathering_spec.rb
+++ b/src/spec/features/interest_gathering_spec.rb
@@ -12,7 +12,7 @@ feature "Gauging interest in a session" do
 
   scenario "As a guest, I want to express my interest", js: true do
 
-    click_link "A neat talk"
+    click_link "A neat talk", match: :first
     page.find("#attend").click
 
     fill_in "Name", with: "Dennis Ritchie"
@@ -28,7 +28,7 @@ feature "Gauging interest in a session" do
   scenario "As a signed in user I want to express my interest", js: true do
     sign_in_user user
 
-    click_link "A neat talk"
+    click_link "A neat talk", match: :first
     page.find("#attend").click
 
     expect(page).to have_content 'Thanks for your interest in this session.'


### PR DESCRIPTION
Some quick & dirty changes to ease (though not totally address) #85.

Background: the current UI shows just a few sessions _most recent_ first, and the “all sessions” page shows them _least recent_ first. This favors the very first and last sessions created, and leaves sessions in the middle a bit undervoted. The oldest ones get especially overvoted, in part because they're visible longer, and in part because you have to scroll so far on the “all sessions” page to see the newer ones.

I suspect that we'd get better data for the scheduler if we displayed a more even sampling of sessions in the UI. I made a few of the easier changes that might address that:

- Sessions home now shows a random sampling of sessions first, then recently added, then by category. Those first two are shorter than the current HP’s list.
- “All sessions” page shows most recently created first instead of least recent. (In earlier discussion, @look didn't like the idea of randomizing these because that would make it too hard to work through the list. I agree.)
- All sessions page now has a 2-column layout, so (1) less scrolling and (2) those underrepresented sessions in the middle are now right at the top of the right column.

Really wish we could have some AJAX-y think where you can vote and _unvote_ sessions straight from the session lists by clicking a little icon or something. (There's currently no way to unvote sessions!) Alas, that's much more involved & I don't have time for it. Anyone else want to grab it?