### PR TITLE
Update cache key for session list

### DIFF
--- a/src/app/views/sessions/index.html.erb
+++ b/src/app/views/sessions/index.html.erb
@@ -1,7 +1,7 @@
 <% title('All Sessions') %>
 (most recently added first)
 
-<% cache [Session.maximum(:updated_at), current_participant] do %>
+<% cache @sessions do %>
   <div class="row">
     <p><%= add_sessions_button %></p>
     <div class="column grid_10" style="margin-left:0px">


### PR DESCRIPTION
Using the built in cache key so that when a session is removed the cache is poisoned.  See http://blog.bigbinary.com/2016/02/02/activerecord-relation-cache-key.html
