### PR TITLE
Schedule UI improvements

### DIFF
--- a/src/app/assets/stylesheets/schedule-mobile.css.sass
+++ b/src/app/assets/stylesheets/schedule-mobile.css.sass
@@ -13,19 +13,19 @@
       float: left !important
   #schedule-body
     .schedule-header
-      padding-top: 2em
+      text-align: center
+      padding-bottom: 1em
       .controls
-        margin: 1.6em 0
-        float: none !important
+        float: none
+        margin: 3em 0 2em
+        a
+          padding: 0.6ex 1em
       .hint
         clear: both
     .schedule
       .timeslot
-        .disabled
-          h2
-            font-size: 1.4em !important
-            padding-top: 0
-            padding-bottom: 0.1em
+        h2
+          font-size: 1.4em !important
         .sessions
           .column
             width: 100% !important

--- a/src/app/assets/stylesheets/schedule-print.css.sass
+++ b/src/app/assets/stylesheets/schedule-print.css.sass
@@ -1,8 +1,11 @@
-#schedule-body
-  font-size: 0.6em !important
-  .nav-top
-    display: none
-  .schedule-header
-    padding-top: 1em
-    .hint, .controls
+@media print
+  #schedule-body
+    font-size: 0.6em !important
+    .nav-top
       display: none
+    .schedule-header
+      padding-top: 1em
+      .hint, .controls
+        display: none
+    .timeslot
+      outline: 6px solid red

--- a/src/app/assets/stylesheets/schedule.css.sass
+++ b/src/app/assets/stylesheets/schedule.css.sass
@@ -1,4 +1,6 @@
 #schedule-body
+  $heading-background: #676ab1
+
   margin: 0
   padding: 0
   
@@ -13,7 +15,7 @@
     color: white
     padding: 0.6em 2%
     box-shadow: 0 -0.2ex 1ex black
-    background: #676ab1
+    background: mix($heading-background, black)
 
     a
       float: left
@@ -39,12 +41,14 @@
         
   
   .schedule-header
-    padding: 2em
-    padding-top: 4em
-    background: #f0f0f0
+    padding: 4em 2em
+    padding-top: 6em
+    background: $heading-background
+    color: white
     h1
       margin: 0
       padding: 0
+      color: white
       font:
         family: 'Helvetica Neue', 'Verdana', sans-serif
         weight: bold
@@ -52,7 +56,7 @@
     
     .hint
       margin: 1ex 0
-      color: #777
+      color: #ccc
       font:
         family: 'Helvetica Neue', 'Verdana', sans-serif
         size: 90%
@@ -60,12 +64,11 @@
     .controls
       float: right
       a
-        display: block
-        float: right
+        display: inline-block
         margin-right: 1em
         padding: 1ex 1em
         border-radius: 2em
-        border: 1px solid #888
+        border: 0.5px solid rgba(0, 0, 0, 0.5)
         background: #e8e8e8
         color: #003
         white-space: nowrap
@@ -83,7 +86,7 @@
   .schedule
     .timeslot
       clear: both
-      padding-top: 0.8em
+      border-top: 0.5px solid mix($heading-background, black)
       &:first-child
         padding-top: 0
       h2
@@ -91,10 +94,10 @@
           family: 'Helvetica Neue', 'Verdana', sans-serif
           size: 1.8em !important
         color: white
-        margin: 0 0 0.4em 0
+        margin: 0
         font-weight: bold
-        padding: 0.3em 1em
-        background: #676ab1
+        padding: 0.8em 1em
+        background: $heading-background
         .time, .title
           display: inline-block
           vertical-align: top

--- a/src/app/controllers/admin/admin_controller.rb
+++ b/src/app/controllers/admin/admin_controller.rb
@@ -6,7 +6,7 @@ class Admin::AdminController < ApplicationController
 
   def redirect_to_ssl
     if Rails.env.production? && !request.ssl?
-      redirect_to "https://sessionizer.herokuapp.com/admin/sessions/new"
+      redirect_to(protocol: 'https://')
     end
   end
 

--- a/src/app/controllers/schedules_controller.rb
+++ b/src/app/controllers/schedules_controller.rb
@@ -59,7 +59,13 @@ class SchedulesController < ApplicationController
 
   def schedule(event)
     Rails.cache.fetch("#{event.cache_key}/schedule", expires_in: 10.minutes) do
-      Event.includes(timeslots: { sessions: [:room, :presenters] }).find(event.id)
+      event = Event.includes(timeslots: { sessions: [:room, :presenters] }).find(event.id)
+
+      # Preload vote counts in order to sort sessions by popularity
+      Session.preload_attendance_counts(
+        event.timeslots.map(&:sessions).flatten)
+
+      event
     end
   end
 

--- a/src/app/helpers/schedules_helper.rb
+++ b/src/app/helpers/schedules_helper.rb
@@ -68,7 +68,7 @@ module SchedulesHelper
 
     columns.map! { |col| col.sort_by { |s| session_sort_order(s) } }
     unless columns[0].empty? || columns[1].empty?
-      if session_room_capacity(columns[0].first) < session_room_capacity(columns[1].first)
+      if columns[0].first.attendance_count < columns[1].first.attendance_count
         columns = [columns[1], columns[0]]
       end
     end
@@ -77,10 +77,6 @@ module SchedulesHelper
   end
 
 private
-
-  def session_room_capacity(session)
-    session.room&.capacity || 0
-  end
 
   def session_sort_order(session)
     [-session.attendance_count, session.room&.name || ""]

--- a/src/app/helpers/schedules_helper.rb
+++ b/src/app/helpers/schedules_helper.rb
@@ -12,6 +12,8 @@ module SchedulesHelper
     end
   end
 
+private
+
   def stable_room_order_session_columns_for_slot(slot, &block)
     sessions = slot.sessions.sort_by { |s| session_sort_order(s) }
     split = (sessions.size+1) / 2
@@ -19,9 +21,9 @@ module SchedulesHelper
     yield sessions[split..-1]
   end
 
-  ##
   # Attempt to divide these sessions into two roughly equal groups of roughly equal height.
   # (Without this, the fully expanded details grow very lopsided.)
+  #
   def balanced_session_columns_for_slot(slot, &block)
 
     unassigned = slot.sessions.sort_by { |s| -estimated_height(s) }
@@ -75,8 +77,6 @@ module SchedulesHelper
 
     columns.each(&block)
   end
-
-private
 
   def session_sort_order(session)
     [-session.attendance_count, session.room&.name || ""]

--- a/src/app/helpers/schedules_helper.rb
+++ b/src/app/helpers/schedules_helper.rb
@@ -13,7 +13,7 @@ module SchedulesHelper
   end
 
   def stable_room_order_session_columns_for_slot(slot, &block)
-    sessions = slot.sessions.sort_by { |s| [-s.room.capacity, s.room.name] }
+    sessions = slot.sessions.sort_by { |s| session_sort_order(s) }
     split = (sessions.size+1) / 2
     yield sessions[0...split]
     yield sessions[split..-1]
@@ -66,9 +66,9 @@ module SchedulesHelper
 
     # Now yield each column with session sorted by room size.
 
-    columns.map! { |col| col.sort_by { |s| [-s.room.capacity, s.room.name] } }
+    columns.map! { |col| col.sort_by { |s| session_sort_order(s) } }
     unless columns[0].empty? || columns[1].empty?
-      if columns[0].first.room.capacity < columns[1].first.room.capacity
+      if session_room_capacity(columns[0].first) < session_room_capacity(columns[1].first)
         columns = [columns[1], columns[0]]
       end
     end
@@ -77,6 +77,18 @@ module SchedulesHelper
   end
 
 private
+
+  def session_room_capacity(session)
+    session.room&.capacity || 0
+  end
+
+  def session_sort_order(session)
+    if room = session.room
+      [-room.capacity, room.name]
+    else
+      [0, ""]
+    end
+  end
 
   def estimated_height(session)
     if session.instance_variable_get(:@estimated_height).blank?

--- a/src/app/helpers/schedules_helper.rb
+++ b/src/app/helpers/schedules_helper.rb
@@ -83,11 +83,7 @@ private
   end
 
   def session_sort_order(session)
-    if room = session.room
-      [-room.capacity, room.name]
-    else
-      [0, ""]
-    end
+    [-session.attendance_count, session.room&.name || ""]
   end
 
   def estimated_height(session)

--- a/src/app/models/session.rb
+++ b/src/app/models/session.rb
@@ -116,11 +116,15 @@ class Session < ActiveRecord::Base
     end
   end
 
+  # The raw number of votes for this session.
+  #
+  # To avoid O(n) queries, use preload_attendance_counts if you’ll be calling this on a
+  # collection of sessions.
+  #
   def attendance_count
     @attendance_count ||= attendances.count
   end
-
-  attr_writer :attendance_count
+  attr_writer :attendance_count  # for preload
 
   def self.preload_attendance_counts(sessions)
     sessions_by_id = {}
@@ -128,6 +132,8 @@ class Session < ActiveRecord::Base
       sessions_by_id[session.id] = session
     end
     
+    # Surely there’s a Rails helper for this?
+    # But I can’t find it — only some abandoned gems.
     Attendance
       .select("session_id, count(*) as attendance_count")
       .where('session_id in (?)', sessions_by_id.keys)

--- a/src/app/views/layouts/schedule.html.erb
+++ b/src/app/views/layouts/schedule.html.erb
@@ -3,11 +3,8 @@
   <head>
     <%= csrf_meta_tags %>
     <title><%= @event.name %> &ndash; Session Schedule</title>
-    <%= stylesheet_link_tag 'grid' %>
-    <%= stylesheet_link_tag 'schedule', :media => 'screen, print' %>
-    <%= stylesheet_link_tag 'schedule-print', :media => 'print' %>
-    <%= stylesheet_link_tag 'schedule-mobile', :media => 'screen' %>
-    <%= javascript_include_tag 'schedule' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
     <%= favicon_link_tag 'favicon.ico' %>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/src/app/views/timeslots/_timeslot.html.haml
+++ b/src/app/views/timeslots/_timeslot.html.haml
@@ -13,9 +13,10 @@
 
             .session
               .header
-                - map_location = asset_path("maps/#{session.room.name.downcase}.png")
-                .room{:href =>  "#{map_location}" }
-                  = session.room.name
+                - if session.room
+                  - map_location = asset_path("maps/#{session.room.name.downcase}.png")
+                  .room{:href =>  "#{map_location}" }
+                    = session.room.name
 
                 %h3.title= session.title
 

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -12,7 +12,11 @@ module Sessionizer
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    config.eager_load_paths << config.root.join('lib') 
+    config.eager_load_paths << config.root.join('lib')
+
+    # We want to always show times in Minnebar’s time zone, regardless of where
+    # the use is located.
+
     config.time_zone = 'US/Central'
   end
 end

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -13,5 +13,6 @@ module Sessionizer
     # -- all .rb files in that directory are automatically loaded.
 
     config.eager_load_paths << config.root.join('lib') 
+    config.time_zone = 'US/Central'
   end
 end


### PR DESCRIPTION
A grab bag:

- Schedule page now works even if sessions don’t have rooms yet. This is in anticipation of getting the schedule out early this year, and assigning rooms only later.
- The schedule — and the whole app! — should always show dates in Central Time, regardless of the user’s device’s time zone.
- Fixed broken CSS/JS includes (probably got hosed during the Rails 5 migration?).
- Mopped up some layout stuff that got messy with incremental fixes over the years.
- Fixed broken URL in http → https admin redirect. (Should we force https site-wide?)