### PR TITLE
Prompt users to log in to see votes on schedule

### DIFF
--- a/src/app/assets/stylesheets/schedule.css.sass
+++ b/src/app/assets/stylesheets/schedule.css.sass
@@ -45,6 +45,9 @@
     padding-top: 6em
     background: $heading-background
     color: white
+    a
+      color: white
+      font-weight: 600
     h1
       margin: 0
       padding: 0
@@ -53,6 +56,8 @@
         family: 'Helvetica Neue', 'Verdana', sans-serif
         weight: bold
         size: 2em
+    p
+      margin: 1em 0 0 0
     
     .hint
       margin: 1ex 0

--- a/src/app/controllers/user_sessions_controller.rb
+++ b/src/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,8 @@
 class UserSessionsController < ApplicationController
   def new
+    if params[:after_login]
+      session[:after_login] = params[:after_login]
+    end
     @participant_session = ParticipantSession.new
   end
 
@@ -7,7 +10,8 @@ class UserSessionsController < ApplicationController
     @participant_session = ParticipantSession.new(participant_session_params)
     if @participant_session.save
       flash[:notice] = "You're logged in. Welcome back."
-      redirect_to root_path
+      redirect_to session[:after_login] || root_path
+      session.delete(:after_login)
     else
       flash.now[:error] = "Sorry, couldn't find that participant. Try again, or sign up to register a new account."
       render :action => :new

--- a/src/app/views/schedules/index.html.haml
+++ b/src/app/views/schedules/index.html.haml
@@ -1,4 +1,4 @@
-- cache [@event.sessions, @event.timeslots] do
+- cache [current_participant.nil?, @event.sessions, @event.timeslots] do
   = render 'header'
   .schedule
     .schedule-header
@@ -9,6 +9,10 @@
       %h1
         = @event.name
         Session Schedule
+      - if current_participant.nil?
+        %p
+          = link_to 'Log in', new_login_path(after_login: schedule_path(foo: 'bar'))
+          to mark your favorite sessions
     .timeslots
       = render event_timeslots
 


### PR DESCRIPTION
This adds a link to the top of the schedule mentioning that you can now actually see your favorited sessions if you log in. People are likely to have logged in on their desktop but be checking the schedule from mobile, and not realize it's actually worth bothering to log in now.

Innocent little change, and I’m going to go ahead and merge it — but leaving this PR here for any discussion.