### PR TITLE
Performance improvements and caching for /sessions.json

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -28,4 +28,15 @@ class ApplicationController < ActionController::Base
       redirect_to new_login_path
     end
   end
+
+  def event_schedule_cache_key(event)
+    [
+      event,
+      event.sessions,
+      event.participants,
+      event.timeslots,
+      event.rooms
+    ]
+  end
+  helper_method :event_schedule_cache_key
 end

--- a/src/app/models/sessions_json_builder.rb
+++ b/src/app/models/sessions_json_builder.rb
@@ -20,7 +20,7 @@ class SessionsJsonBuilder
       categories: s.categories.map(&:name),
       other_presenter_names: s.other_presenter_names,
       other_presenter_ids: s.other_presenters.map(&:id),
-      attendance_count: s.attendances.count,
+      attendance_count: s.attendance_count,
       created_at: s.created_at.utc,
       updated_at: s.updated_at.utc
     }

--- a/src/app/views/schedules/index.html.haml
+++ b/src/app/views/schedules/index.html.haml
@@ -1,4 +1,4 @@
-- cache [current_participant.nil?, @event.sessions, @event.timeslots] do
+- cache [current_participant.nil?] + event_schedule_cache_key(@event), expires_in: 10.minutes do
   = render 'header'
   .schedule
     .schedule-header

--- a/src/app/views/sessions/index.html.erb
+++ b/src/app/views/sessions/index.html.erb
@@ -1,7 +1,7 @@
 <% title('All Sessions') %>
 (most recently added first)
 
-<% cache [@sessions, current_participant] do  # fragment contains user-specific info %>
+<% cache [current_participant] + event_schedule_cache_key(@event) do  # fragment contains user-specific info %>
   <div class="row">
     <p><%= add_sessions_button %></p>
     <div class="column grid_10" style="margin-left:0px">


### PR DESCRIPTION
Somebody out there is polling `/sessions.json`, and it takes as much as 9 seconds per request.

This PR stops the database explosion that controller causes (for a ~4.5x speedup), and also caches the response (for a ~100x speedup when the cache is fresh).

I'm going to deploy this tonight rather than right before the event starts tomorrow morning, but I’m leaving this PR in case anybody else is having fun reviewing code on a Friday night.