### PR TITLE
Allow a way to add a name to presenters that don't have one

### DIFF
--- a/src/app/controllers/admin/presenters_controller.rb
+++ b/src/app/controllers/admin/presenters_controller.rb
@@ -33,8 +33,12 @@ class Admin::PresentersController < Admin::AdminController
 
   private
 
+  # Cast blank values to nil (e.g. 'email' => '') because this trips a uniqueness
+  # constraint in the database.
   def presenter_params
-    params.require(:participant).permit(:name, :email, :bio)
+    params.require(:participant).permit(:name, :email, :bio).to_h.each_with_object({}) do |(k, v), h|
+      h[k] = v.blank? ? nil : v
+    end
   end
 
 

--- a/src/app/controllers/admin/presenters_controller.rb
+++ b/src/app/controllers/admin/presenters_controller.rb
@@ -12,12 +12,13 @@ class Admin::PresentersController < Admin::AdminController
   end
 
   def update
-    if @presenter.update(presenter_params)
-      flash[:success] = "Presenter updated."
-      redirect_to admin_presenters_path
-    else
-      render :edit
-    end
+    # We may only want to update the name here but leave the email address blank
+    # so skip validations.  This presenter may have been created by
+    # Admin::SessionsController, which does not set an email address.
+    @presenter.attributes = presenter_params
+    @presenter.save(validate: false)
+    flash[:success] = "Presenter updated."
+    redirect_to admin_presenters_path
   end
 
   def export

--- a/src/app/views/admin/presenters/edit.html.erb
+++ b/src/app/views/admin/presenters/edit.html.erb
@@ -6,7 +6,7 @@
   <%= f.inputs do %>
     <%= f.input :name, :label => 'Name' %>
     <%= f.input :email, :label => 'Email' %>
-    <%= f.input :bio, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <strong>**bold**</strong>, <em>*italic*</em>, [link](http://example.com)' %>
+    <%= f.input :bio, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <strong>**bold**</strong>, <em>*italic*</em>, [link](http://example.com)'.html_safe %>
   <% end %>
 
   <%= f.actions %>

--- a/src/app/views/admin/sessions/edit.html.erb
+++ b/src/app/views/admin/sessions/edit.html.erb
@@ -8,7 +8,7 @@
     <%= f.input :title %>
 
     <div>
-      By <%= @session.presenters.map {|p| link_to p.name, p }.to_sentence.html_safe %>
+      By <%= @session.presenters.map { |p| link_to p.name.presence || '(No name)', edit_admin_presenter_path(p) }.to_sentence.html_safe %>
     </div>
 
     <%= f.input :description, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <b>**bold**</b>, <i>*italic*</i>, [link](http://example.com)'.html_safe %>

--- a/src/spec/controllers/admin/presenters_controller_spec.rb
+++ b/src/spec/controllers/admin/presenters_controller_spec.rb
@@ -44,11 +44,15 @@ RSpec.describe Admin::PresentersController do
       it 'allows updating some fields' do
         put :update, params: { id: presenter,
                                participant: {
-                                 name: 'The father of LISP'
+                                 name: 'The father of LISP',
+                                 email: ''
                                } }
         expect(response).to redirect_to admin_presenters_path
         expect(flash[:success]).to eq 'Presenter updated.'
-        expect(presenter.reload.name).to eq 'The father of LISP'
+        presenter.reload
+        expect(presenter.name).to eq 'The father of LISP'
+        expect(presenter.email).to be_nil
+
       end
     end
   end

--- a/src/spec/controllers/admin/presenters_controller_spec.rb
+++ b/src/spec/controllers/admin/presenters_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Admin::PresentersController do
+RSpec.describe Admin::PresentersController do
 
   let(:presenter) { FactoryGirl.create(:participant, name: 'John McCarthy', email: 'parens@example.org') }
   let(:event) { FactoryGirl.create(:event) }
@@ -22,16 +22,34 @@ describe Admin::PresentersController do
     end
   end
 
-  describe "#update" do
-    it "should be successful" do
-      put :update, params: {id: presenter, participant: {
-                                  name: 'The father of LISP', email: 'g@example.org', bio: "Functionally just another dude"
-                                }
-                            }
-      expect(response).to redirect_to admin_presenters_path
-      expect(flash[:success]).to eq "Presenter updated."
-      expect(assigns[:presenter]).to eq presenter
-      expect(assigns[:presenter].name).to eq 'The father of LISP'
+  describe '#update' do
+    context 'setting all fields' do
+      it 'is successful' do
+        put :update, params: { id: presenter,
+                               participant: {
+                                 name: 'The father of LISP',
+                                 email: 'g@example.org',
+                                 bio: 'Functionally just another dude'
+                               } }
+        expect(response).to redirect_to admin_presenters_path
+        expect(flash[:success]).to eq 'Presenter updated.'
+        expect(assigns[:presenter]).to eq presenter
+        expect(assigns[:presenter].name).to eq 'The father of LISP'
+      end
+    end
+
+    context 'when the presenter is not valid (created by Admin::SessionsController)' do
+      let(:presenter) { Participant.new.tap { |p| p.save(validate: false) } }
+
+      it 'allows updating some fields' do
+        put :update, params: { id: presenter,
+                               participant: {
+                                 name: 'The father of LISP'
+                               } }
+        expect(response).to redirect_to admin_presenters_path
+        expect(flash[:success]).to eq 'Presenter updated.'
+        expect(presenter.reload.name).to eq 'The father of LISP'
+      end
     end
   end
 


### PR DESCRIPTION
It is possible to create a session without a presenter from the admin
page.  Once you do that, you may want to add the presenter's name at a
latter time.  In order to do that we need three changes:

1. Create a clickable link by showing alternate text when name is
missing.
2. Changing the link to get to the particpant edit page.
3. Allowing the admin presenter controller to accept some missing values
(e.g. email)