### PR TITLE
Make multiple blank users rather than just one.

### DIFF
--- a/src/app/controllers/admin/sessions_controller.rb
+++ b/src/app/controllers/admin/sessions_controller.rb
@@ -26,8 +26,13 @@ class Admin::SessionsController < Admin::AdminController
   def build_presenter
     name = params[:session].delete(:name)
     # find exact match by name
-    Participant.where(name: name).first_or_initialize do |p|
-      p.save(validate: false) if p.new_record?
+    if name.present?
+      Participant.where(name: name).first_or_initialize do |p|
+        p.save(validate: false) if p.new_record?
+      end
+    else
+      # Create a blank participant. We can add a name/email to this person later.
+      Participant.new.tap { |p| p.save(validate: false) }
     end
   end
 

--- a/src/spec/controllers/admin/sessions_controller_spec.rb
+++ b/src/spec/controllers/admin/sessions_controller_spec.rb
@@ -63,6 +63,28 @@ describe Admin::SessionsController do
       end
     end
 
+    context 'when name is left blank' do
+      let(:session_params) do
+        {
+          session: {
+            title: 'new title',
+            description: 'new description',
+            name: ''
+          }
+        }
+      end
+
+      it 'creates a new session with a new user' do
+        expect {
+          post :create, params: session_params
+        }.to change { Session.count }.by(1)
+         .and change { Participant.count }.by(1)
+        expect(response).to redirect_to admin_sessions_path
+        expect(assigns[:session].title).to eq 'new title'
+        expect(assigns[:session].participant.name).to be_nil
+      end
+    end
+
     context "with invalid values" do
       it "shows the errors" do
 
@@ -82,4 +104,3 @@ describe Admin::SessionsController do
     end
   end
 end
-


### PR DESCRIPTION
Presently if you make a bunch of sessions with a blank name, they are
all assigned to the same presenter.  This poses a problem if you later
want to change the presenters name.  It would change the name for all
unassigned sessions. This makes one presenter for each unassigned
session. This allows us to set different names at a later time.