### PR TITLE
Remove the implied Lukeness from the factory session

### DIFF
--- a/src/spec/controllers/schedules_controller_spec.rb
+++ b/src/spec/controllers/schedules_controller_spec.rb
@@ -39,8 +39,12 @@ describe SchedulesController do
 
   describe "#ical" do
     let(:timeslot) { create(:timeslot) }
-    let!(:session) { create(:session, timeslot: timeslot, event: timeslot.event) }
-
+    let!(:session) do
+      create(:session,
+             event: timeslot.event,
+             timeslot: timeslot,
+             participant: create(:luke))
+    end
     it "is successful" do
       get :ical
       expect(response).to be_successful

--- a/src/spec/factories/session.rb
+++ b/src/spec/factories/session.rb
@@ -1,13 +1,10 @@
 
 FactoryGirl.define do
-
   factory :session do
-
-    title "Stuff about things"
-    description "whatever"
-    participant { create :luke }
+    title 'Stuff about things'
+    description 'whatever'
+    participant
     association :event
     association :room
-
   end
 end

--- a/src/spec/models/sessions_json_builder_spec.rb
+++ b/src/spec/models/sessions_json_builder_spec.rb
@@ -1,14 +1,14 @@
 require "spec_helper"
 
-describe SessionsJsonBuilder do
+RSpec.describe SessionsJsonBuilder do
   let(:event) { create(:event) }
-  let(:session) { create(:session, event: event) } 
+  let(:session) { create(:session, event: event, participant: create(:luke)) }
 
-  describe "to_hash" do
-    subject { SessionsJsonBuilder.new }
-    it "should have all the attributes" do
-      h = subject.to_hash(session)
+  describe '#to_hash' do
+    let(:builder) { SessionsJsonBuilder.new }
+    subject(:h) { builder.to_hash(session) }
 
+    it 'has all the attributes' do
       expect(h[:id]).to be session.id
       expect(h[:participant_id]).to be session.participant_id
 
@@ -32,7 +32,6 @@ describe SessionsJsonBuilder do
       expect(h[:attendance_count]).to be session.attendances.count
       expect(h[:created_at]).to be session.created_at.utc
       expect(h[:updated_at]).to be session.updated_at.utc
-
     end
   end
 end


### PR DESCRIPTION
If Lukeness is required, make it explicit.  This fixes a problem when
you try to use the session factory twice and it complains that Luke's
email is already taken.

Sorry @look 