### PR TITLE
Add version number to migrations

### DIFF
--- a/src/db/migrate/20100414215724_create_sessions.rb
+++ b/src/db/migrate/20100414215724_create_sessions.rb
@@ -1,4 +1,4 @@
-class CreateSessions < ActiveRecord::Migration
+class CreateSessions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :sessions do |t|
       t.belongs_to :participant, :null => false

--- a/src/db/migrate/20100414224830_create_categories.rb
+++ b/src/db/migrate/20100414224830_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration
+class CreateCategories < ActiveRecord::Migration[4.2]
   def self.up
     create_table :categories do |t|
       t.string :name, :null => false

--- a/src/db/migrate/20100414231806_create_categorizations.rb
+++ b/src/db/migrate/20100414231806_create_categorizations.rb
@@ -1,4 +1,4 @@
-class CreateCategorizations < ActiveRecord::Migration
+class CreateCategorizations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :categorizations do |t|
       t.integer :category_id, :null => false

--- a/src/db/migrate/20100423205652_create_participants.rb
+++ b/src/db/migrate/20100423205652_create_participants.rb
@@ -1,4 +1,4 @@
-class CreateParticipants < ActiveRecord::Migration
+class CreateParticipants < ActiveRecord::Migration[4.2]
   def self.up
     create_table :participants do |t|
       t.string :name

--- a/src/db/migrate/20100423214500_create_attendances.rb
+++ b/src/db/migrate/20100423214500_create_attendances.rb
@@ -1,4 +1,4 @@
-class CreateAttendances < ActiveRecord::Migration
+class CreateAttendances < ActiveRecord::Migration[4.2]
   def self.up
     create_table :attendances do |t|
       t.belongs_to :session, :null => false

--- a/src/db/migrate/20110414023923_create_events.rb
+++ b/src/db/migrate/20110414023923_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def self.up
     create_table :events do |t|
       t.string :name, :null => false

--- a/src/db/migrate/20110414025659_add_event_to_session.rb
+++ b/src/db/migrate/20110414025659_add_event_to_session.rb
@@ -1,4 +1,4 @@
-class AddEventToSession < ActiveRecord::Migration
+class AddEventToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :event_id, :int
   end

--- a/src/db/migrate/20120325234743_create_timeslots.rb
+++ b/src/db/migrate/20120325234743_create_timeslots.rb
@@ -1,4 +1,4 @@
-class CreateTimeslots < ActiveRecord::Migration
+class CreateTimeslots < ActiveRecord::Migration[4.2]
   def self.up
     create_table :timeslots do |t|
       t.belongs_to :event, :null => false

--- a/src/db/migrate/20120326003621_add_timeslot_to_session.rb
+++ b/src/db/migrate/20120326003621_add_timeslot_to_session.rb
@@ -1,4 +1,4 @@
-class AddTimeslotToSession < ActiveRecord::Migration
+class AddTimeslotToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :timeslot_id, :integer
   end

--- a/src/db/migrate/20120326004820_create_rooms.rb
+++ b/src/db/migrate/20120326004820_create_rooms.rb
@@ -1,4 +1,4 @@
-class CreateRooms < ActiveRecord::Migration
+class CreateRooms < ActiveRecord::Migration[4.2]
   def self.up
     create_table :rooms do |t|
       t.belongs_to :event, :null => false

--- a/src/db/migrate/20120326004834_add_room_to_session.rb
+++ b/src/db/migrate/20120326004834_add_room_to_session.rb
@@ -1,4 +1,4 @@
-class AddRoomToSession < ActiveRecord::Migration
+class AddRoomToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :room_id, :integer
   end

--- a/src/db/migrate/20120330060456_add_presentations.rb
+++ b/src/db/migrate/20120330060456_add_presentations.rb
@@ -1,4 +1,4 @@
-class AddPresentations < ActiveRecord::Migration
+class AddPresentations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :presentations, :force => true do |t|
       t.integer :session_id

--- a/src/db/migrate/20120401214321_create_presenter_timeslot_restrictions.rb
+++ b/src/db/migrate/20120401214321_create_presenter_timeslot_restrictions.rb
@@ -1,4 +1,4 @@
-class CreatePresenterTimeslotRestrictions < ActiveRecord::Migration
+class CreatePresenterTimeslotRestrictions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :presenter_timeslot_restrictions, :force => true do |t|
       t.integer :participant_id

--- a/src/db/migrate/20120403022345_make_timeslot_use_timestamp.rb
+++ b/src/db/migrate/20120403022345_make_timeslot_use_timestamp.rb
@@ -1,4 +1,4 @@
-class MakeTimeslotUseTimestamp < ActiveRecord::Migration
+class MakeTimeslotUseTimestamp < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :timeslots, :starts_at
     remove_column :timeslots, :ends_at

--- a/src/db/migrate/20120404031433_add_summary_to_session.rb
+++ b/src/db/migrate/20120404031433_add_summary_to_session.rb
@@ -1,4 +1,4 @@
-class AddSummaryToSession < ActiveRecord::Migration
+class AddSummaryToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :summary, :string
   end

--- a/src/db/migrate/20130224225306_make_participant_authenticatable.rb
+++ b/src/db/migrate/20130224225306_make_participant_authenticatable.rb
@@ -1,4 +1,4 @@
-class MakeParticipantAuthenticatable < ActiveRecord::Migration
+class MakeParticipantAuthenticatable < ActiveRecord::Migration[4.2]
   def up
     add_column :participants, :crypted_password, :string
     add_column :participants, :persistence_token, :string

--- a/src/db/migrate/20130304053159_add_level_to_sessions.rb
+++ b/src/db/migrate/20130304053159_add_level_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddLevelToSessions < ActiveRecord::Migration
+class AddLevelToSessions < ActiveRecord::Migration[4.2]
   def change
     change_table :sessions do |t|
       t.belongs_to :level

--- a/src/db/migrate/20130304053929_create_levels.rb
+++ b/src/db/migrate/20130304053929_create_levels.rb
@@ -1,4 +1,4 @@
-class CreateLevels < ActiveRecord::Migration
+class CreateLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :levels do |t|
       t.string :name

--- a/src/db/migrate/20150319011702_add_perishable_token_to_users.rb
+++ b/src/db/migrate/20150319011702_add_perishable_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddPerishableTokenToUsers < ActiveRecord::Migration
+class AddPerishableTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :perishable_token, :string, :default => "", :null => false
     add_index :participants, :perishable_token

--- a/src/db/migrate/20150414022055_create_settings.rb
+++ b/src/db/migrate/20150414022055_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def change
     create_table :settings do |t|
       t.boolean :show_schedule

--- a/src/db/migrate/20150911192254_add_schedulable_and_title_to_timeslot.rb
+++ b/src/db/migrate/20150911192254_add_schedulable_and_title_to_timeslot.rb
@@ -1,4 +1,4 @@
-class AddSchedulableAndTitleToTimeslot < ActiveRecord::Migration
+class AddSchedulableAndTitleToTimeslot < ActiveRecord::Migration[4.2]
   def change
     add_column :timeslots, :schedulable, :boolean, default: true
     add_column :timeslots, :title, :string

--- a/src/db/migrate/20150920192518_add_schedulable_to_room.rb
+++ b/src/db/migrate/20150920192518_add_schedulable_to_room.rb
@@ -1,4 +1,4 @@
-class AddSchedulableToRoom < ActiveRecord::Migration
+class AddSchedulableToRoom < ActiveRecord::Migration[4.2]
   def change
     add_column :rooms, :schedulable, :boolean, default: true
   end

--- a/src/db/migrate/20160319173736_add_more_attributes_to_participant.rb
+++ b/src/db/migrate/20160319173736_add_more_attributes_to_participant.rb
@@ -1,4 +1,4 @@
-class AddMoreAttributesToParticipant < ActiveRecord::Migration
+class AddMoreAttributesToParticipant < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :github_profile_username, :string #github username
     add_column :participants, :github_og_image, :string # github avatar

--- a/src/db/migrate/20160420042853_add_manually_scheduled_to_sessions.rb
+++ b/src/db/migrate/20160420042853_add_manually_scheduled_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddManuallyScheduledToSessions < ActiveRecord::Migration
+class AddManuallyScheduledToSessions < ActiveRecord::Migration[4.2]
   def change
     add_column :sessions, :manually_scheduled, :boolean, null: false, default: false
   end


### PR DESCRIPTION
Otherwise you can't run `rake db:migrate` on rails 5.1