### PR TITLE
Fix cut-off session titles

### DIFF
--- a/src/app/assets/stylesheets/shared.css.scss
+++ b/src/app/assets/stylesheets/shared.css.scss
@@ -128,6 +128,7 @@ div.sidebar-box {
 ul.sessionsList {
   margin: 0;
   padding: 0;
+  padding-right: 2.2em;
   list-style-type: none;
   @include columns(24em, 1em);
   li.attending {


### PR DESCRIPTION
Session titles were being cut off due to the padding for the buttons that appear when you're signed in and can express your interest. 