### PR TITLE
Added scripts for starting up app and server; updated migrations; added instructions for Docker

### DIFF
--- a/README-ruby_on_racetracks.md
+++ b/README-ruby_on_racetracks.md
@@ -1,10 +1,10 @@
-# Starting this App the Ruby on Racetracks Way
+# Ruby on Racetracks
 
 Under the Ruby on Racetracks system, you can be ready to roll in MINUTES instead of hours.  Because it uses Docker instead of Vagrant, you never have to wait for a Vagrant box to boot up.  Scripts are provided to automate the process of setting up this project.
 
 ## Prerequisites
-* Install Docker.  More details on how to do this are in the [Different Docker Tutorial](http://www.differentdockertutorial.com/).
 * If you are using a Mac or Windows system, you need a Linux virtual machine.  More details on how to install a Linux virtual machine are in the [VirtualBox Tutorial](http://www.virtualboxtutorial.com/).
+* Install Docker.  More details on how to do this are in the [Different Docker Tutorial](http://www.differentdockertutorial.com/).  Please go through each of the chapters in the first 3 units to familiarize yourself with the Ruby on Racetracks way of using Docker.  Do NOT be intimidated by the large number of chapters, because each chapter is short.
 
 ## Starting the Docker Container
 * Enter the following commands:
@@ -23,17 +23,14 @@ sh download_new_image.sh
 * After the Docker image has been downloaded, you will automatically be logged into the Docker container.  By default, your Docker terminal will be in the shared directory.
 
 ## Setup
-* From the shared directory in the Docker container, enter the following command to download this app:
-```
-git clone https://github.com/minnestar/sessionizer.git
-```
+* From the shared directory in the Docker container, "git clone" this repository.
 * Enter the command "tmux".  This starts up tmux.  You are in Window 0.
 * Enter the following commands:
 ```
 cd sessionizer
 sh credentials.sh # Enter your Git name and email address when prompted.
 ```
-* Press Ctrl-b and then Ctrl-c to start a second tmux window.  You are in Window 1.
+* Press Ctrl-b and then Ctrl-c to start a second tmux window.  You are in Window 1.  Press Ctrl-p to go to the previous tmux window.  Press Ctrl-n to go to the next tmux window.
 * 
 * Enter the following commands:
 ```
@@ -43,3 +40,7 @@ sh build_fast.sh; sh server.sh
 * The build_fast.sh script automatically sets up the project for you.  This will take a few minutes.
 * The server.sh script runs the local Rails server so that you can view the app in your browser.
 * After the setup process is finished and after the Rails server is up and running, you can view your app.  If your Docker port offset is 0, the URL is http://localhost:3000.  If your Docker port offset is different, the port number to use in your browser is also different.  If your port number is "4", the URL is http://localhost:3000.  If you forget what your port number assignments are, they are in the ports.txt file in the shared directory.
+* To view the previous page in the a window, press Ctrl-b and then the page up button (or Fn/up arrow combination on a Mac).  To view the next page in a tmux window, press press the page down button (or the Fn/down arrow combination on a Mac).  To exit the page up/page down mode, press Ctrl-C.
+* To resume the Docker container in the same condition in which you left it, enter the command "sh resume.sh".
+* To reset the Docker container to the original conditions stored in the Docker image, enter the command "sh reset.sh".  You'll need to run the credentials.sh script to provide your Git name and email address, and you'll need to to run the build_fast.sh script to set up the project again.
+

--- a/README-ruby_on_racetracks.md
+++ b/README-ruby_on_racetracks.md
@@ -1,0 +1,45 @@
+# Starting this App the Ruby on Racetracks Way
+
+Under the Ruby on Racetracks system, you can be ready to roll in MINUTES instead of hours.  Because it uses Docker instead of Vagrant, you never have to wait for a Vagrant box to boot up.  Scripts are provided to automate the process of setting up this project.
+
+## Prerequisites
+* Install Docker.  More details on how to do this are in the [Different Docker Tutorial](http://www.differentdockertutorial.com/).
+* If you are using a Mac or Windows system, you need a Linux virtual machine.  More details on how to install a Linux virtual machine are in the [VirtualBox Tutorial](http://www.virtualboxtutorial.com/).
+
+## Starting the Docker Container
+* Enter the following commands:
+```
+cd
+mkdir jhsu802701
+cd jhsu802701
+git clone https://gitlab.com/jhsu802701/docker-debian-stretch.git
+cd docker-debian-stretch
+sh rails-sessionizer.sh # Pick a port number offset.
+cd rails-sessionizer
+sh download_new_image.sh
+```
+* It will take a few minutes for the Docker image to be downloaded.
+* Please note that if you used a non-zero port offset, the port number in the Docker image corresponds to a different port number in the host system.  The port assignments are in the ports.txt file in the shared directory.  If you entered "4", port number 3000 in Docker corresponds to port number 3004 in the host system, port number 1080 in Docker corresponds to port 1084 in the host system, and port number 5432 in Docker corresponds to port 15436 in the host system.
+* After the Docker image has been downloaded, you will automatically be logged into the Docker container.  By default, your Docker terminal will be in the shared directory.
+
+## Setup
+* From the shared directory in the Docker container, enter the following command to download this app:
+```
+git clone https://github.com/minnestar/sessionizer.git
+```
+* Enter the command "tmux".  This starts up tmux.  You are in Window 0.
+* Enter the following commands:
+```
+cd sessionizer
+sh credentials.sh # Enter your Git name and email address when prompted.
+```
+* Press Ctrl-b and then Ctrl-c to start a second tmux window.  You are in Window 1.
+* 
+* Enter the following commands:
+```
+cd sessionizer/src
+sh build_fast.sh; sh server.sh
+```
+* The build_fast.sh script automatically sets up the project for you.  This will take a few minutes.
+* The server.sh script runs the local Rails server so that you can view the app in your browser.
+* After the setup process is finished and after the Rails server is up and running, you can view your app.  If your Docker port offset is 0, the URL is http://localhost:3000.  If your Docker port offset is different, the port number to use in your browser is also different.  If your port number is "4", the URL is http://localhost:3000.  If you forget what your port number assignments are, they are in the ports.txt file in the shared directory.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Sessionizer is a tool for managing session registration for unconferences. It wa
 
 ## Running
 
-### Bootstrapping
+### Bootstrapping (Quick Way)
+Go to the README-ruby_on_racetracks.md file in this repository for the quick way to set up and run this app on your local machine.
+
+### Bootstrapping (Slow Way)
 
 You'll need to install [VirtualBox][], [Vagrant][], and [Ansible][]
 first. VirtualBox and Vagrant both have Mac OS X installer packages, and

--- a/credentials.sh
+++ b/credentials.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script provides one-stop shopping for entering your credentials.
+# Please run this script when you reset the Docker container.
+# The "git commit" command will not work without your Git credentials.
+
+# Output:
+# First argument if it is not blank
+# Second argument if first argument is blank
+anti_blank () {
+  if [ -z "$1" ]; then
+    echo "$2"
+  else
+    echo "$1"
+  fi
+}
+
+echo '***********************'
+echo 'SETTING GIT CREDENTIALS'
+EMAIL_DEF='you@example.com'
+
+echo
+echo "Default email address: ${EMAIL_DEF}"
+echo
+echo 'Enter your Git email address:'
+read EMAIL_SEL
+EMAIL=$(anti_blank $EMAIL_SEL $EMAIL_DEF)
+echo
+
+echo
+echo '------------------------------'
+echo "git config --global user.email"
+echo "$EMAIL"
+git config --global user.email "$EMAIL"
+
+NAME_DEF='Your Name'
+echo
+echo "Default name: ${NAME_DEF}"
+echo
+echo 'Enter your Git name:'
+read NAME_SEL
+
+# NOTE: The double quotes are needed to avoid truncating the string
+# at the space.
+NAME=$(anti_blank "$NAME_SEL" "$NAME_DEF")
+
+echo
+echo '-----------------------------'
+echo "git config --global user.name"
+echo "$NAME"
+git config --global user.name "$NAME"
+echo

--- a/src/build_fast.sh
+++ b/src/build_fast.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+PG_VERSION="$(ls /etc/postgresql)"
+PG_HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
+
+echo '-------------------'
+echo "Configuring $PG_HBA"
+
+sudo bash -c "echo '# TYPE  DATABASE        USER            ADDRESS                 METHOD' > $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# Allow vagrant user to connect to database without password' >> $PG_HBA"
+sudo bash -c "echo 'local   all             vagrant                                 trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# Allow postgres user to connect to database without password' >> $PG_HBA"
+sudo bash -c "echo 'local   all             postgres                                trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo 'local   all             all                                     trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# IPv4 local connections:' >> $PG_HBA"
+sudo bash -c "echo 'host    all             all             0.0.0.0/0               trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# IPv6 local connections:' >> $PG_HBA"
+sudo bash -c "echo 'host    all             all             ::1/128                 trust' >> $PG_HBA"
+
+echo '-----------------------------'
+echo 'sudo service postgresql start'
+sudo service postgresql start
+
+echo '----------------------------------'
+echo 'sudo /etc/init.d/postgresql reload'
+sudo /etc/init.d/postgresql reload
+
+export TEST_DATABASE_USERNAME=postgres
+
+echo '--------------'
+echo 'bundle install'
+bundle install
+
+echo '--------------------------------------'
+echo 'sudo -u postgres createuser -d vagrant'
+sudo -u postgres createuser -d vagrant
+
+echo '------------------------------------------------------'
+echo "'create database sessionizer_development;' -U postgres"
+psql -c 'create database sessionizer_development;' -U postgres
+
+echo '-------------------------------------------------------'
+echo "psql -c 'create database sessionizer_test;' -U postgres"
+psql -c 'create database sessionizer_test;' -U postgres
+
+sh test_app.sh

--- a/src/db/migrate/20100414215724_create_sessions.rb
+++ b/src/db/migrate/20100414215724_create_sessions.rb
@@ -1,4 +1,4 @@
-class CreateSessions < ActiveRecord::Migration
+class CreateSessions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :sessions do |t|
       t.belongs_to :participant, :null => false

--- a/src/db/migrate/20100414224830_create_categories.rb
+++ b/src/db/migrate/20100414224830_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration
+class CreateCategories < ActiveRecord::Migration[4.2]
   def self.up
     create_table :categories do |t|
       t.string :name, :null => false

--- a/src/db/migrate/20100414231806_create_categorizations.rb
+++ b/src/db/migrate/20100414231806_create_categorizations.rb
@@ -1,4 +1,4 @@
-class CreateCategorizations < ActiveRecord::Migration
+class CreateCategorizations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :categorizations do |t|
       t.integer :category_id, :null => false

--- a/src/db/migrate/20100423205652_create_participants.rb
+++ b/src/db/migrate/20100423205652_create_participants.rb
@@ -1,4 +1,4 @@
-class CreateParticipants < ActiveRecord::Migration
+class CreateParticipants < ActiveRecord::Migration[4.2]
   def self.up
     create_table :participants do |t|
       t.string :name

--- a/src/db/migrate/20100423214500_create_attendances.rb
+++ b/src/db/migrate/20100423214500_create_attendances.rb
@@ -1,4 +1,4 @@
-class CreateAttendances < ActiveRecord::Migration
+class CreateAttendances < ActiveRecord::Migration[4.2]
   def self.up
     create_table :attendances do |t|
       t.belongs_to :session, :null => false

--- a/src/db/migrate/20110414023923_create_events.rb
+++ b/src/db/migrate/20110414023923_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def self.up
     create_table :events do |t|
       t.string :name, :null => false

--- a/src/db/migrate/20110414025659_add_event_to_session.rb
+++ b/src/db/migrate/20110414025659_add_event_to_session.rb
@@ -1,4 +1,4 @@
-class AddEventToSession < ActiveRecord::Migration
+class AddEventToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :event_id, :int
   end

--- a/src/db/migrate/20120325234743_create_timeslots.rb
+++ b/src/db/migrate/20120325234743_create_timeslots.rb
@@ -1,4 +1,4 @@
-class CreateTimeslots < ActiveRecord::Migration
+class CreateTimeslots < ActiveRecord::Migration[4.2]
   def self.up
     create_table :timeslots do |t|
       t.belongs_to :event, :null => false

--- a/src/db/migrate/20120326003621_add_timeslot_to_session.rb
+++ b/src/db/migrate/20120326003621_add_timeslot_to_session.rb
@@ -1,4 +1,4 @@
-class AddTimeslotToSession < ActiveRecord::Migration
+class AddTimeslotToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :timeslot_id, :integer
   end

--- a/src/db/migrate/20120326004820_create_rooms.rb
+++ b/src/db/migrate/20120326004820_create_rooms.rb
@@ -1,4 +1,4 @@
-class CreateRooms < ActiveRecord::Migration
+class CreateRooms < ActiveRecord::Migration[4.2]
   def self.up
     create_table :rooms do |t|
       t.belongs_to :event, :null => false

--- a/src/db/migrate/20120326004834_add_room_to_session.rb
+++ b/src/db/migrate/20120326004834_add_room_to_session.rb
@@ -1,4 +1,4 @@
-class AddRoomToSession < ActiveRecord::Migration
+class AddRoomToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :room_id, :integer
   end

--- a/src/db/migrate/20120330060456_add_presentations.rb
+++ b/src/db/migrate/20120330060456_add_presentations.rb
@@ -1,4 +1,4 @@
-class AddPresentations < ActiveRecord::Migration
+class AddPresentations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :presentations, :force => true do |t|
       t.integer :session_id

--- a/src/db/migrate/20120401214321_create_presenter_timeslot_restrictions.rb
+++ b/src/db/migrate/20120401214321_create_presenter_timeslot_restrictions.rb
@@ -1,4 +1,4 @@
-class CreatePresenterTimeslotRestrictions < ActiveRecord::Migration
+class CreatePresenterTimeslotRestrictions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :presenter_timeslot_restrictions, :force => true do |t|
       t.integer :participant_id

--- a/src/db/migrate/20120403022345_make_timeslot_use_timestamp.rb
+++ b/src/db/migrate/20120403022345_make_timeslot_use_timestamp.rb
@@ -1,4 +1,4 @@
-class MakeTimeslotUseTimestamp < ActiveRecord::Migration
+class MakeTimeslotUseTimestamp < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :timeslots, :starts_at
     remove_column :timeslots, :ends_at

--- a/src/db/migrate/20120404031433_add_summary_to_session.rb
+++ b/src/db/migrate/20120404031433_add_summary_to_session.rb
@@ -1,4 +1,4 @@
-class AddSummaryToSession < ActiveRecord::Migration
+class AddSummaryToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :summary, :string
   end

--- a/src/db/migrate/20130224225306_make_participant_authenticatable.rb
+++ b/src/db/migrate/20130224225306_make_participant_authenticatable.rb
@@ -1,4 +1,4 @@
-class MakeParticipantAuthenticatable < ActiveRecord::Migration
+class MakeParticipantAuthenticatable < ActiveRecord::Migration[4.2]
   def up
     add_column :participants, :crypted_password, :string
     add_column :participants, :persistence_token, :string

--- a/src/db/migrate/20130304053159_add_level_to_sessions.rb
+++ b/src/db/migrate/20130304053159_add_level_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddLevelToSessions < ActiveRecord::Migration
+class AddLevelToSessions < ActiveRecord::Migration[4.2]
   def change
     change_table :sessions do |t|
       t.belongs_to :level

--- a/src/db/migrate/20130304053929_create_levels.rb
+++ b/src/db/migrate/20130304053929_create_levels.rb
@@ -1,4 +1,4 @@
-class CreateLevels < ActiveRecord::Migration
+class CreateLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :levels do |t|
       t.string :name

--- a/src/db/migrate/20150319011702_add_perishable_token_to_users.rb
+++ b/src/db/migrate/20150319011702_add_perishable_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddPerishableTokenToUsers < ActiveRecord::Migration
+class AddPerishableTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :perishable_token, :string, :default => "", :null => false
     add_index :participants, :perishable_token

--- a/src/db/migrate/20150414022055_create_settings.rb
+++ b/src/db/migrate/20150414022055_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def change
     create_table :settings do |t|
       t.boolean :show_schedule

--- a/src/db/migrate/20150911192254_add_schedulable_and_title_to_timeslot.rb
+++ b/src/db/migrate/20150911192254_add_schedulable_and_title_to_timeslot.rb
@@ -1,4 +1,4 @@
-class AddSchedulableAndTitleToTimeslot < ActiveRecord::Migration
+class AddSchedulableAndTitleToTimeslot < ActiveRecord::Migration[4.2]
   def change
     add_column :timeslots, :schedulable, :boolean, default: true
     add_column :timeslots, :title, :string

--- a/src/db/migrate/20150920192518_add_schedulable_to_room.rb
+++ b/src/db/migrate/20150920192518_add_schedulable_to_room.rb
@@ -1,4 +1,4 @@
-class AddSchedulableToRoom < ActiveRecord::Migration
+class AddSchedulableToRoom < ActiveRecord::Migration[4.2]
   def change
     add_column :rooms, :schedulable, :boolean, default: true
   end

--- a/src/db/migrate/20160319173736_add_more_attributes_to_participant.rb
+++ b/src/db/migrate/20160319173736_add_more_attributes_to_participant.rb
@@ -1,4 +1,4 @@
-class AddMoreAttributesToParticipant < ActiveRecord::Migration
+class AddMoreAttributesToParticipant < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :github_profile_username, :string #github username
     add_column :participants, :github_og_image, :string # github avatar

--- a/src/db/migrate/20160420042853_add_manually_scheduled_to_sessions.rb
+++ b/src/db/migrate/20160420042853_add_manually_scheduled_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddManuallyScheduledToSessions < ActiveRecord::Migration
+class AddManuallyScheduledToSessions < ActiveRecord::Migration[4.2]
   def change
     add_column :sessions, :manually_scheduled, :boolean, null: false, default: false
   end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -15,112 +15,112 @@ ActiveRecord::Schema.define(version: 20170324203935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "attendances", force: :cascade do |t|
-    t.integer  "session_id",     null: false
-    t.integer  "participant_id", null: false
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.index ["session_id", "participant_id"], name: "index_attendances_on_session_id_and_participant_id", unique: true, using: :btree
+  create_table "attendances", id: :serial, force: :cascade do |t|
+    t.integer "session_id", null: false
+    t.integer "participant_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["session_id", "participant_id"], name: "index_attendances_on_session_id_and_participant_id", unique: true
   end
 
-  create_table "categories", force: :cascade do |t|
-    t.string "name", limit: 255, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true, using: :btree
+  create_table "categories", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table "categorizations", force: :cascade do |t|
-    t.integer  "category_id", null: false
-    t.integer  "session_id",  null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["category_id", "session_id"], name: "index_categorizations_on_category_id_and_session_id", unique: true, using: :btree
+  create_table "categorizations", id: :serial, force: :cascade do |t|
+    t.integer "category_id", null: false
+    t.integer "session_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["category_id", "session_id"], name: "index_categorizations_on_category_id_and_session_id", unique: true
   end
 
-  create_table "events", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
-    t.date     "date",                   null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+  create_table "events", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.date "date", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "levels", force: :cascade do |t|
-    t.string "name", limit: 255
+  create_table "levels", id: :serial, force: :cascade do |t|
+    t.string "name"
   end
 
-  create_table "participants", force: :cascade do |t|
-    t.string   "name",                    limit: 255
-    t.string   "email",                   limit: 255
-    t.text     "bio"
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.string   "crypted_password",        limit: 255
-    t.string   "persistence_token",       limit: 255
-    t.string   "perishable_token",        limit: 255, default: "", null: false
-    t.string   "github_profile_username"
-    t.string   "github_og_image"
-    t.string   "github_og_url"
-    t.string   "twitter_handle"
-    t.index ["email"], name: "index_participants_on_email", unique: true, using: :btree
-    t.index ["perishable_token"], name: "index_participants_on_perishable_token", using: :btree
+  create_table "participants", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.text "bio"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "crypted_password"
+    t.string "persistence_token"
+    t.string "perishable_token", default: "", null: false
+    t.string "github_profile_username"
+    t.string "github_og_image"
+    t.string "github_og_url"
+    t.string "twitter_handle"
+    t.index ["email"], name: "index_participants_on_email", unique: true
+    t.index ["perishable_token"], name: "index_participants_on_perishable_token"
   end
 
-  create_table "presentations", force: :cascade do |t|
-    t.integer  "session_id"
-    t.integer  "participant_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+  create_table "presentations", id: :serial, force: :cascade do |t|
+    t.integer "session_id"
+    t.integer "participant_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "presenter_timeslot_restrictions", force: :cascade do |t|
-    t.integer  "participant_id"
-    t.integer  "timeslot_id"
-    t.float    "weight"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.index ["timeslot_id", "participant_id"], name: "present_timeslot_participant_unique", unique: true, using: :btree
+  create_table "presenter_timeslot_restrictions", id: :serial, force: :cascade do |t|
+    t.integer "participant_id"
+    t.integer "timeslot_id"
+    t.float "weight"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["timeslot_id", "participant_id"], name: "present_timeslot_participant_unique", unique: true
   end
 
-  create_table "rooms", force: :cascade do |t|
-    t.integer  "event_id",                               null: false
-    t.string   "name",        limit: 255,                null: false
-    t.integer  "capacity"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.boolean  "schedulable",             default: true
+  create_table "rooms", id: :serial, force: :cascade do |t|
+    t.integer "event_id", null: false
+    t.string "name", null: false
+    t.integer "capacity"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "schedulable", default: true
   end
 
-  create_table "sessions", force: :cascade do |t|
-    t.integer  "participant_id",                                         null: false
-    t.string   "title",                      limit: 255,                 null: false
-    t.text     "description",                                            null: false
-    t.boolean  "panel",                                  default: false, null: false
-    t.boolean  "projector",                              default: false, null: false
-    t.datetime "created_at",                                             null: false
-    t.datetime "updated_at",                                             null: false
-    t.integer  "event_id"
-    t.integer  "timeslot_id"
-    t.integer  "room_id"
-    t.string   "summary",                    limit: 255
-    t.integer  "level_id"
-    t.boolean  "manually_scheduled",                     default: false, null: false
-    t.integer  "manual_attendance_estimate"
-    t.index ["level_id"], name: "index_sessions_on_level_id", using: :btree
+  create_table "sessions", id: :serial, force: :cascade do |t|
+    t.integer "participant_id", null: false
+    t.string "title", null: false
+    t.text "description", null: false
+    t.boolean "panel", default: false, null: false
+    t.boolean "projector", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "event_id"
+    t.integer "timeslot_id"
+    t.integer "room_id"
+    t.string "summary"
+    t.integer "level_id"
+    t.boolean "manually_scheduled", default: false, null: false
+    t.integer "manual_attendance_estimate"
+    t.index ["level_id"], name: "index_sessions_on_level_id"
   end
 
-  create_table "settings", force: :cascade do |t|
+  create_table "settings", id: :serial, force: :cascade do |t|
     t.boolean "show_schedule"
     t.integer "current_event_id"
-    t.index ["current_event_id"], name: "index_settings_on_current_event_id", using: :btree
+    t.index ["current_event_id"], name: "index_settings_on_current_event_id"
   end
 
-  create_table "timeslots", force: :cascade do |t|
-    t.integer  "event_id",                   null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+  create_table "timeslots", id: :serial, force: :cascade do |t|
+    t.integer "event_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "starts_at"
     t.datetime "ends_at"
-    t.boolean  "schedulable", default: true
-    t.string   "title"
+    t.boolean "schedulable", default: true
+    t.string "title"
   end
 
 end

--- a/src/server.sh
+++ b/src/server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo '-----------------------------'
+echo 'sudo service postgresql start'
+sudo service postgresql start
+
+echo '--------------------------------------------------'
+echo 'View page in your browser at http://localhost:3000'
+echo 'If you are using Docker with a non-zero port offset,'
+echo 'then the appropriate port number is different from 3000.'
+
+if [ -f '/home/winner/shared/ports.txt' ]; then
+  cat /home/winner/shared/ports.txt;
+fi
+
+echo '-------------------------------'
+echo 'rails server -b 0.0.0.0 -p 3000'
+rails server -b 0.0.0.0 -p 3000

--- a/src/test_app.sh
+++ b/src/test_app.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo '--------------'
+echo 'bundle install'
+bundle install
+
+echo '----------------'
+echo 'rails db:migrate'
+rails db:migrate
+
+echo '----------------------'
+echo 'bundle exec rspec spec'
+bundle exec rspec spec


### PR DESCRIPTION
* I updated the migration scripts, because I was getting the following error message:
```
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for
```
* I made no other changes in how the app runs.
* The only other change I made to a pre-existing file in this app was updating the README.md file to direct the reader to the README-ruby_on_racetracks.md file for a faster way to get started.
* Running build_fast.sh script automatically sets up this app in only one step.  (It includes the process of configuring PostgreSQL.)  Those who prefer the old way are free to ignore it.
* The server.sh script automatically sets up this app for the Ruby on Racetracks way.
* The test_app.sh script is called by the build_fast.sh script.  It runs "bundle install", the database migration scripts, and the tests.