### PR TITLE
Updated the migration scripts

### DIFF
--- a/src/db/migrate/20100414215724_create_sessions.rb
+++ b/src/db/migrate/20100414215724_create_sessions.rb
@@ -1,4 +1,4 @@
-class CreateSessions < ActiveRecord::Migration
+class CreateSessions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :sessions do |t|
       t.belongs_to :participant, :null => false

--- a/src/db/migrate/20100414224830_create_categories.rb
+++ b/src/db/migrate/20100414224830_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration
+class CreateCategories < ActiveRecord::Migration[4.2]
   def self.up
     create_table :categories do |t|
       t.string :name, :null => false

--- a/src/db/migrate/20100414231806_create_categorizations.rb
+++ b/src/db/migrate/20100414231806_create_categorizations.rb
@@ -1,4 +1,4 @@
-class CreateCategorizations < ActiveRecord::Migration
+class CreateCategorizations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :categorizations do |t|
       t.integer :category_id, :null => false

--- a/src/db/migrate/20100423205652_create_participants.rb
+++ b/src/db/migrate/20100423205652_create_participants.rb
@@ -1,4 +1,4 @@
-class CreateParticipants < ActiveRecord::Migration
+class CreateParticipants < ActiveRecord::Migration[4.2]
   def self.up
     create_table :participants do |t|
       t.string :name

--- a/src/db/migrate/20100423214500_create_attendances.rb
+++ b/src/db/migrate/20100423214500_create_attendances.rb
@@ -1,4 +1,4 @@
-class CreateAttendances < ActiveRecord::Migration
+class CreateAttendances < ActiveRecord::Migration[4.2]
   def self.up
     create_table :attendances do |t|
       t.belongs_to :session, :null => false

--- a/src/db/migrate/20110414023923_create_events.rb
+++ b/src/db/migrate/20110414023923_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def self.up
     create_table :events do |t|
       t.string :name, :null => false

--- a/src/db/migrate/20110414025659_add_event_to_session.rb
+++ b/src/db/migrate/20110414025659_add_event_to_session.rb
@@ -1,4 +1,4 @@
-class AddEventToSession < ActiveRecord::Migration
+class AddEventToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :event_id, :int
   end

--- a/src/db/migrate/20120325234743_create_timeslots.rb
+++ b/src/db/migrate/20120325234743_create_timeslots.rb
@@ -1,4 +1,4 @@
-class CreateTimeslots < ActiveRecord::Migration
+class CreateTimeslots < ActiveRecord::Migration[4.2]
   def self.up
     create_table :timeslots do |t|
       t.belongs_to :event, :null => false

--- a/src/db/migrate/20120326003621_add_timeslot_to_session.rb
+++ b/src/db/migrate/20120326003621_add_timeslot_to_session.rb
@@ -1,4 +1,4 @@
-class AddTimeslotToSession < ActiveRecord::Migration
+class AddTimeslotToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :timeslot_id, :integer
   end

--- a/src/db/migrate/20120326004820_create_rooms.rb
+++ b/src/db/migrate/20120326004820_create_rooms.rb
@@ -1,4 +1,4 @@
-class CreateRooms < ActiveRecord::Migration
+class CreateRooms < ActiveRecord::Migration[4.2]
   def self.up
     create_table :rooms do |t|
       t.belongs_to :event, :null => false

--- a/src/db/migrate/20120326004834_add_room_to_session.rb
+++ b/src/db/migrate/20120326004834_add_room_to_session.rb
@@ -1,4 +1,4 @@
-class AddRoomToSession < ActiveRecord::Migration
+class AddRoomToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :room_id, :integer
   end

--- a/src/db/migrate/20120330060456_add_presentations.rb
+++ b/src/db/migrate/20120330060456_add_presentations.rb
@@ -1,4 +1,4 @@
-class AddPresentations < ActiveRecord::Migration
+class AddPresentations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :presentations, :force => true do |t|
       t.integer :session_id

--- a/src/db/migrate/20120401214321_create_presenter_timeslot_restrictions.rb
+++ b/src/db/migrate/20120401214321_create_presenter_timeslot_restrictions.rb
@@ -1,4 +1,4 @@
-class CreatePresenterTimeslotRestrictions < ActiveRecord::Migration
+class CreatePresenterTimeslotRestrictions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :presenter_timeslot_restrictions, :force => true do |t|
       t.integer :participant_id

--- a/src/db/migrate/20120403022345_make_timeslot_use_timestamp.rb
+++ b/src/db/migrate/20120403022345_make_timeslot_use_timestamp.rb
@@ -1,4 +1,4 @@
-class MakeTimeslotUseTimestamp < ActiveRecord::Migration
+class MakeTimeslotUseTimestamp < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :timeslots, :starts_at
     remove_column :timeslots, :ends_at

--- a/src/db/migrate/20120404031433_add_summary_to_session.rb
+++ b/src/db/migrate/20120404031433_add_summary_to_session.rb
@@ -1,4 +1,4 @@
-class AddSummaryToSession < ActiveRecord::Migration
+class AddSummaryToSession < ActiveRecord::Migration[4.2]
   def self.up
     add_column :sessions, :summary, :string
   end

--- a/src/db/migrate/20130224225306_make_participant_authenticatable.rb
+++ b/src/db/migrate/20130224225306_make_participant_authenticatable.rb
@@ -1,4 +1,4 @@
-class MakeParticipantAuthenticatable < ActiveRecord::Migration
+class MakeParticipantAuthenticatable < ActiveRecord::Migration[4.2]
   def up
     add_column :participants, :crypted_password, :string
     add_column :participants, :persistence_token, :string

--- a/src/db/migrate/20130304053159_add_level_to_sessions.rb
+++ b/src/db/migrate/20130304053159_add_level_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddLevelToSessions < ActiveRecord::Migration
+class AddLevelToSessions < ActiveRecord::Migration[4.2]
   def change
     change_table :sessions do |t|
       t.belongs_to :level

--- a/src/db/migrate/20130304053929_create_levels.rb
+++ b/src/db/migrate/20130304053929_create_levels.rb
@@ -1,4 +1,4 @@
-class CreateLevels < ActiveRecord::Migration
+class CreateLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :levels do |t|
       t.string :name

--- a/src/db/migrate/20150319011702_add_perishable_token_to_users.rb
+++ b/src/db/migrate/20150319011702_add_perishable_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddPerishableTokenToUsers < ActiveRecord::Migration
+class AddPerishableTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :perishable_token, :string, :default => "", :null => false
     add_index :participants, :perishable_token

--- a/src/db/migrate/20150414022055_create_settings.rb
+++ b/src/db/migrate/20150414022055_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def change
     create_table :settings do |t|
       t.boolean :show_schedule

--- a/src/db/migrate/20150911192254_add_schedulable_and_title_to_timeslot.rb
+++ b/src/db/migrate/20150911192254_add_schedulable_and_title_to_timeslot.rb
@@ -1,4 +1,4 @@
-class AddSchedulableAndTitleToTimeslot < ActiveRecord::Migration
+class AddSchedulableAndTitleToTimeslot < ActiveRecord::Migration[4.2]
   def change
     add_column :timeslots, :schedulable, :boolean, default: true
     add_column :timeslots, :title, :string

--- a/src/db/migrate/20150920192518_add_schedulable_to_room.rb
+++ b/src/db/migrate/20150920192518_add_schedulable_to_room.rb
@@ -1,4 +1,4 @@
-class AddSchedulableToRoom < ActiveRecord::Migration
+class AddSchedulableToRoom < ActiveRecord::Migration[4.2]
   def change
     add_column :rooms, :schedulable, :boolean, default: true
   end

--- a/src/db/migrate/20160319173736_add_more_attributes_to_participant.rb
+++ b/src/db/migrate/20160319173736_add_more_attributes_to_participant.rb
@@ -1,4 +1,4 @@
-class AddMoreAttributesToParticipant < ActiveRecord::Migration
+class AddMoreAttributesToParticipant < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :github_profile_username, :string #github username
     add_column :participants, :github_og_image, :string # github avatar

--- a/src/db/migrate/20160420042853_add_manually_scheduled_to_sessions.rb
+++ b/src/db/migrate/20160420042853_add_manually_scheduled_to_sessions.rb
@@ -1,4 +1,4 @@
-class AddManuallyScheduledToSessions < ActiveRecord::Migration
+class AddManuallyScheduledToSessions < ActiveRecord::Migration[4.2]
   def change
     add_column :sessions, :manually_scheduled, :boolean, null: false, default: false
   end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -15,112 +15,112 @@ ActiveRecord::Schema.define(version: 20170324203935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "attendances", force: :cascade do |t|
-    t.integer  "session_id",     null: false
-    t.integer  "participant_id", null: false
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.index ["session_id", "participant_id"], name: "index_attendances_on_session_id_and_participant_id", unique: true, using: :btree
+  create_table "attendances", id: :serial, force: :cascade do |t|
+    t.integer "session_id", null: false
+    t.integer "participant_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["session_id", "participant_id"], name: "index_attendances_on_session_id_and_participant_id", unique: true
   end
 
-  create_table "categories", force: :cascade do |t|
-    t.string "name", limit: 255, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true, using: :btree
+  create_table "categories", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table "categorizations", force: :cascade do |t|
-    t.integer  "category_id", null: false
-    t.integer  "session_id",  null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["category_id", "session_id"], name: "index_categorizations_on_category_id_and_session_id", unique: true, using: :btree
+  create_table "categorizations", id: :serial, force: :cascade do |t|
+    t.integer "category_id", null: false
+    t.integer "session_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["category_id", "session_id"], name: "index_categorizations_on_category_id_and_session_id", unique: true
   end
 
-  create_table "events", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
-    t.date     "date",                   null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+  create_table "events", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.date "date", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "levels", force: :cascade do |t|
-    t.string "name", limit: 255
+  create_table "levels", id: :serial, force: :cascade do |t|
+    t.string "name"
   end
 
-  create_table "participants", force: :cascade do |t|
-    t.string   "name",                    limit: 255
-    t.string   "email",                   limit: 255
-    t.text     "bio"
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.string   "crypted_password",        limit: 255
-    t.string   "persistence_token",       limit: 255
-    t.string   "perishable_token",        limit: 255, default: "", null: false
-    t.string   "github_profile_username"
-    t.string   "github_og_image"
-    t.string   "github_og_url"
-    t.string   "twitter_handle"
-    t.index ["email"], name: "index_participants_on_email", unique: true, using: :btree
-    t.index ["perishable_token"], name: "index_participants_on_perishable_token", using: :btree
+  create_table "participants", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.text "bio"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "crypted_password"
+    t.string "persistence_token"
+    t.string "perishable_token", default: "", null: false
+    t.string "github_profile_username"
+    t.string "github_og_image"
+    t.string "github_og_url"
+    t.string "twitter_handle"
+    t.index ["email"], name: "index_participants_on_email", unique: true
+    t.index ["perishable_token"], name: "index_participants_on_perishable_token"
   end
 
-  create_table "presentations", force: :cascade do |t|
-    t.integer  "session_id"
-    t.integer  "participant_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+  create_table "presentations", id: :serial, force: :cascade do |t|
+    t.integer "session_id"
+    t.integer "participant_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "presenter_timeslot_restrictions", force: :cascade do |t|
-    t.integer  "participant_id"
-    t.integer  "timeslot_id"
-    t.float    "weight"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.index ["timeslot_id", "participant_id"], name: "present_timeslot_participant_unique", unique: true, using: :btree
+  create_table "presenter_timeslot_restrictions", id: :serial, force: :cascade do |t|
+    t.integer "participant_id"
+    t.integer "timeslot_id"
+    t.float "weight"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["timeslot_id", "participant_id"], name: "present_timeslot_participant_unique", unique: true
   end
 
-  create_table "rooms", force: :cascade do |t|
-    t.integer  "event_id",                               null: false
-    t.string   "name",        limit: 255,                null: false
-    t.integer  "capacity"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.boolean  "schedulable",             default: true
+  create_table "rooms", id: :serial, force: :cascade do |t|
+    t.integer "event_id", null: false
+    t.string "name", null: false
+    t.integer "capacity"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "schedulable", default: true
   end
 
-  create_table "sessions", force: :cascade do |t|
-    t.integer  "participant_id",                                         null: false
-    t.string   "title",                      limit: 255,                 null: false
-    t.text     "description",                                            null: false
-    t.boolean  "panel",                                  default: false, null: false
-    t.boolean  "projector",                              default: false, null: false
-    t.datetime "created_at",                                             null: false
-    t.datetime "updated_at",                                             null: false
-    t.integer  "event_id"
-    t.integer  "timeslot_id"
-    t.integer  "room_id"
-    t.string   "summary",                    limit: 255
-    t.integer  "level_id"
-    t.boolean  "manually_scheduled",                     default: false, null: false
-    t.integer  "manual_attendance_estimate"
-    t.index ["level_id"], name: "index_sessions_on_level_id", using: :btree
+  create_table "sessions", id: :serial, force: :cascade do |t|
+    t.integer "participant_id", null: false
+    t.string "title", null: false
+    t.text "description", null: false
+    t.boolean "panel", default: false, null: false
+    t.boolean "projector", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "event_id"
+    t.integer "timeslot_id"
+    t.integer "room_id"
+    t.string "summary"
+    t.integer "level_id"
+    t.boolean "manually_scheduled", default: false, null: false
+    t.integer "manual_attendance_estimate"
+    t.index ["level_id"], name: "index_sessions_on_level_id"
   end
 
-  create_table "settings", force: :cascade do |t|
+  create_table "settings", id: :serial, force: :cascade do |t|
     t.boolean "show_schedule"
     t.integer "current_event_id"
-    t.index ["current_event_id"], name: "index_settings_on_current_event_id", using: :btree
+    t.index ["current_event_id"], name: "index_settings_on_current_event_id"
   end
 
-  create_table "timeslots", force: :cascade do |t|
-    t.integer  "event_id",                   null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+  create_table "timeslots", id: :serial, force: :cascade do |t|
+    t.integer "event_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "starts_at"
     t.datetime "ends_at"
-    t.boolean  "schedulable", default: true
-    t.string   "title"
+    t.boolean "schedulable", default: true
+    t.string "title"
   end
 
 end


### PR DESCRIPTION
* Specifying the Rails release that the migrations were written for is necessary.  Without the migration script updates, the following message appeared:
```
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for
```
* These changes in this pull request allow the "rails db:migrate" command to proceed and allow the tests to pass.
* No other changes are involved in this pull request.  I will make a number of small pull requests for other changes.