### PR TITLE
Removed the SMTP/Mandrill settings the dev and test environments

### DIFF
--- a/src/config/environments/development.rb
+++ b/src/config/environments/development.rb
@@ -49,16 +49,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   
   HOST = 'sessionizer.vm'
-  config.action_mailer.default_url_options = { host: HOST }
-  ActionMailer::Base.smtp_settings = {
-    :user_name => Rails.application.secrets.mandrill_username,
-    :password => Rails.application.secrets.mandrill_password,
-    :address => 'smtp.mandrillapp.com',
-    :port => 587,
-    :authentication => 'login',
-    :enable_starttls_auto => true,
-    :domain => HOST
-  }
 
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/src/config/environments/test.rb
+++ b/src/config/environments/test.rb
@@ -38,16 +38,6 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   HOST = 'sessionizer.vm'
-  config.action_mailer.default_url_options = { host: HOST }
-  ActionMailer::Base.smtp_settings = {
-    :user_name => Rails.application.secrets.mandrill_username,
-    :password => Rails.application.secrets.mandrill_password,
-    :address => 'smtp.mandrillapp.com',
-    :port => 587,
-    :authentication => 'login',
-    :enable_starttls_auto => true,
-    :domain => HOST
-  }
 
   config.action_mailer.perform_deliveries = false
   config.action_mailer.raise_delivery_errors = true


### PR DESCRIPTION
Removing the SMTP/Mandrill settings in src/config/environments/development.rb allows me to try out the password reset feature in the development environment.  Removing these settings in src/config/environments/test.rb is necessary for providing tests of the password reset feature.