### PR TITLE
Participant profile page now works when there are no events or sessions

### DIFF
--- a/src/app/views/participants/show.html.erb
+++ b/src/app/views/participants/show.html.erb
@@ -36,24 +36,22 @@
 
 <div class="column grid_5">
   <h3>Presenting Sessions</h3>
-
   <% if @participant.sessions_presenting.empty? %>
     <p>This person isn't presenting any sessions.</p>
+  <% else %>
+    <ul class="sessionsList">
+      <%= render :partial => 'session', :collection => @participant.sessions_presenting.for_current_event %>
+    </ul>
   <% end %>
-
-  <ul class="sessionsList">
-    <%= render :partial => 'session', :collection => @participant.sessions_presenting.for_current_event %>
-  </ul>
 </div>
 
 <div class="column grid_5">
   <h3>Participating Sessions</h3>
-
   <% if @participant.sessions_attending.empty? %>
     <p>This person hasn't expressed interested in any sessions yet.</p>
+  <% else %>
+    <ul class="sessionsList">
+      <%= render :partial => 'session', :collection => @participant.sessions_attending.for_current_event %>
+    </ul>
   <% end %>
- 
-  <ul class="sessionsList">
-    <%= render :partial => 'session', :collection => @participant.sessions_attending.for_current_event %>
-  </ul>
 </div>

--- a/src/spec/features/participant_show_spec.rb
+++ b/src/spec/features/participant_show_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+feature 'View participant profile' do
+  context 'With an authenticated user' do 
+    let(:luke) { create(:luke) }
+
+    scenario 'Can view participant profile when there are no events or sessions' do
+      visit participant_path(luke)
+      expect(page).to have_selector('h1', text: 'Luke Francl')
+      expect(page).to have_content 'the man with the master plan'
+      expect(page).to have_content "This person isn't presenting any sessions."
+      expect(page).to have_content "This person hasn't expressed interested in any sessions yet."
+    end
+  end
+end


### PR DESCRIPTION
The participant profile page chokes when there are no sessions or events.  The changes in this pull request fix this by bypassing the displays of sessions when there are none.  I have also added an integration test to verify this.