### PR TITLE
The participant show page works even when there are no events

### DIFF
--- a/src/app/models/session.rb
+++ b/src/app/models/session.rb
@@ -19,7 +19,7 @@ class Session < ActiveRecord::Base
 
   scope :with_attendence_count, -> { select('*').joins("LEFT OUTER JOIN (SELECT session_id, count(id) AS attendence_count FROM attendances GROUP BY session_id) AS attendence_aggregation ON attendence_aggregation.session_id = sessions.id") }
 
-  scope :for_current_event, -> { where(event_id: Event.current_event.id) }
+  scope :for_current_event, -> { where(event_id: Event.current_event.id) unless Event.current_event.nil? }
   scope :for_past_events, -> { where.not(event_id: Event.current_event.id).where("event_id > ?", 0).includes(:event).order('events.date desc') }
 
   scope :recent, -> { order('created_at desc') }

--- a/src/app/models/session.rb
+++ b/src/app/models/session.rb
@@ -19,7 +19,7 @@ class Session < ActiveRecord::Base
 
   scope :with_attendence_count, -> { select('*').joins("LEFT OUTER JOIN (SELECT session_id, count(id) AS attendence_count FROM attendances GROUP BY session_id) AS attendence_aggregation ON attendence_aggregation.session_id = sessions.id") }
 
-  scope :for_current_event, -> { where(event_id: Event.current_event.id) unless Event.current_event.nil? }
+  scope :for_current_event, -> { where(event_id: Event.current_event.id) }
   scope :for_past_events, -> { where.not(event_id: Event.current_event.id).where("event_id > ?", 0).includes(:event).order('events.date desc') }
 
   scope :recent, -> { order('created_at desc') }

--- a/src/app/views/participants/show.html.erb
+++ b/src/app/views/participants/show.html.erb
@@ -60,7 +60,7 @@
   <h3>Participating Sessions</h3>
 
   <% if @participant.sessions_attending.empty? %>
-    <p>This person hasn't expressed interested in any sessions yet.</p>
+    <p>This person hasn't expressed interest in any sessions yet.</p>
   <% end %>
  
   <ul class="sessionsList">

--- a/src/spec/features/participant_show_spec.rb
+++ b/src/spec/features/participant_show_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+feature 'View participant profile' do
+  context 'With an authenticated user' do 
+    let(:luke) { create(:luke) }
+
+    scenario 'Can view participant profile when there are no events or sessions' do
+      visit participant_path(luke)
+      expect(page).to have_selector('h1', text: 'Luke Francl')
+      expect(page).to have_content 'the man with the master plan'
+      expect(page).to have_content "This person isn't presenting any sessions."
+      expect(page).to have_content "This person hasn't expressed interested in any sessions yet."
+    end
+  end
+end

--- a/src/spec/features/participant_show_spec.rb
+++ b/src/spec/features/participant_show_spec.rb
@@ -9,7 +9,7 @@ feature 'View participant profile' do
       expect(page).to have_selector('h1', text: 'Luke Francl')
       expect(page).to have_content 'the man with the master plan'
       expect(page).to have_content "This person isn't presenting any sessions."
-      expect(page).to have_content "This person hasn't expressed interested in any sessions yet."
+      expect(page).to have_content "This person hasn't expressed interest in any sessions yet."
     end
   end
 end

--- a/src/spec/features/participant_show_spec.rb
+++ b/src/spec/features/participant_show_spec.rb
@@ -2,9 +2,12 @@ require "spec_helper"
 
 feature 'View participant profile' do
   context 'With an authenticated user' do 
+    background do
+      create(:event, :full_event)
+    end
     let(:luke) { create(:luke) }
 
-    scenario 'Can view participant profile when there are no events or sessions' do
+    scenario 'Can view participant profile when there are no sessions' do
       visit participant_path(luke)
       expect(page).to have_selector('h1', text: 'Luke Francl')
       expect(page).to have_content 'the man with the master plan'


### PR DESCRIPTION
I added an integration test of the participant show page, and all tests pass.  I updated the for_current_event scope in src/app/models/session.rb so that it wouldn't result in an error message when there are no events.  The only change I made in src/app/views/participants/show.html.erb was to correct a typo.