### PR TITLE
Allow the email mechanisms to work in the development environment

### DIFF
--- a/src/config/environments/development.rb
+++ b/src/config/environments/development.rb
@@ -1,6 +1,12 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # BEGIN: needed for email confirmations
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
+  # END: needed for email confirmations
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
The change in src/config/environments/development.rb in this pull request allows you to use the password reset feature in the local development environment.