### PR TITLE
Add configuration for travis ci deploy to heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,9 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 bundler_args: --without development debug
+
+before_deploy:
+  - git reset --hard
+deploy:
+  provider: heroku
+  on: master


### PR DESCRIPTION
@caseyhelbling I tested this setup with my personal account. 

Not sure how travis is setup for this repo, but I also had to add the following to get postgres to actually run. 
```
services:
- postgresql
```
AFAICT it's probably because it's running on an old ubuntu `trusty` image and has postgres running by default and the new `xenial` images require the configuration.

There's also one part that whoever has credentials needs to do

```
# install travis cli and heroku cli first, then run at the root of the repo, commit and push the changes
travis encrypt $(heroku auth:token) --add deploy.api_key
```

Also, if the app in heroku isn't named `sessionizer` it's necessary to add `app: <app-name>` to the deploy configuration block.