### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <support@minnestar.org>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Sessionizer is a tool for managing session registration for unconferences. It wa
 * Sessions with multiple presenters
 * Participants can express interest in sessions
 * Collaborative recommendation engine for recommending sessions based on similarity of interest
-* Automatic scheduling algorithm that uses simulated annealing to minimize presenter overlap an maximize attendee attendance preferences 
+* Automatic scheduling algorithm that uses simulated annealing to minimize presenter overlap an maximize attendee attendance preferences
 * Mobile optimized display of schedule
 * iCalendar feed of schedule
 * Administrative backend for editing sessions
@@ -48,7 +48,7 @@ To restart the app, you can ssh into the box and run:
     $ vagrant ssh
     vagrant$ sudo service unicorn-sessionizer restart
 
-    -- or -- 
+    -- or --
     vagrant$ railsup
 
 To re-run the provisioning scripts, which are idempotent, you can simply do:
@@ -70,8 +70,8 @@ pass: <inside minne* one password> (ask casey or jamie)
 ### Development (seed data)
 
 For development, run `rake app:make_believe` to hydrate the database with sample
-data. It will reset the database, create an event, participants, timeslots, 
-sessions, and apply randomized participant interest. This does not run the 
+data. It will reset the database, create an event, participants, timeslots,
+sessions, and apply randomized participant interest. This does not run the
 scheduling algorithm.
 
 ```
@@ -81,7 +81,7 @@ scheduling algorithm.
 ```
 
 If you need to restart the unicorn processes within the virtual box you
-can alway use the alias `railsup`. 
+can alway use the alias `railsup`.
 
 
 
@@ -97,8 +97,8 @@ can alway use the alias `railsup`.
    console
 8. Since the app is in a git subtree (src/ directory), you need to push
    the app to heroku like this
- 
-from master  
+
+from master
 
 ```
   $ git subtree push --prefix src heroku master
@@ -125,6 +125,9 @@ Once the scheduler has run, you can see what it produced by visiting `/schedule`
 
 You can tweak the schedule by creating PresenterTimeslotRestrictions (if a person can only present during certain timeslots) or by manually swapping scheduled rooms after the schedule has been created (see `Session.swap_rooms`).
 
+## Code of Conduct
+
+Minnestar is dedicated to providing a harassment-free experience for everyone. All conversations and discussions on GitHub (code, commit comments, issues, pull requests) must be respectful and harassment-free. By contributing to this project, you are agreeing to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Contributors
 
@@ -138,4 +141,4 @@ You can tweak the schedule by creating PresenterTimeslotRestrictions (if a perso
 
 ## License
 
-This project is open source under the MIT license. See `LICENSE.txt` for details.
+This project is open source under the MIT license. See [LICENSE](src/LICENSE.txt) for details.


### PR DESCRIPTION
- Added code of conduct from this https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
- Contact our support email for any violations

I'm open to the language in the code of conduct, but it seemed to reflect our in-person one well.

Fixes #217 