### PR TITLE
Ripped out poltergeist; using default Capybara driver

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -55,9 +55,10 @@ group :test do
   gem 'shoulda-matchers'
   gem "factory_girl_rails", "~> 4.0"
   gem 'database_cleaner'
-  gem 'poltergeist'
+  gem "selenium-webdriver", "~> 4.9"
   gem 'puma'
 end
 
 #https://devcenter.heroku.com/articles/rails-4-asset-pipeline
 gem 'rails_12factor', group: :production
+

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -65,7 +65,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cliver (0.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     coveralls (0.8.23)
@@ -147,10 +146,6 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pg (1.4.5)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -206,6 +201,8 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
+    rexml (3.2.9)
+      strscan
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.4)
@@ -224,6 +221,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -237,6 +235,10 @@ GEM
       tilt (>= 1.1, < 3)
     scrypt (3.0.7)
       ffi-compiler (>= 1.0, < 2.0)
+    selenium-webdriver (4.9.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     simplecov (0.16.1)
@@ -252,6 +254,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.1.0)
     sync (0.5.0)
     temple (0.10.0)
     term-ansicolor (1.7.1)
@@ -272,6 +275,7 @@ GEM
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -299,7 +303,6 @@ DEPENDENCIES
   jquery-rails
   nokogiri
   pg
-  poltergeist
   pry
   puma
   rails (~> 5.2)
@@ -310,6 +313,7 @@ DEPENDENCIES
   rspec-rails (~> 3.1)
   ruby-progressbar
   sass-rails (~> 5.0)
+  selenium-webdriver (~> 4.9)
   shoulda-matchers
   spring
   turbolinks

--- a/src/spec/spec_helper.rb
+++ b/src/spec/spec_helper.rb
@@ -13,8 +13,6 @@ end
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = ENV['TRAVIS'] ? 30 : 15
 require 'capybara/rspec'
 require 'capybara/rails'


### PR DESCRIPTION
Poltergeist is long defunct, and was breaking specs. Switched to Capybara default driver. Specs now all pass again. Yay!

`rails spec` now launches Firefox for integration tests, which is…surprising the first time, but probably fine.