### PR TITLE
Upgrade FactoryGirl to FactoryBot

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -53,7 +53,7 @@ end
 
 group :test do
   gem 'shoulda-matchers'
-  gem "factory_girl_rails", "~> 4.0"
+  gem 'factory_bot_rails'
   gem 'database_cleaner'
   gem "selenium-webdriver", "~> 4.9"
   gem 'puma'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -85,11 +85,11 @@ GEM
     docile (1.4.0)
     erubi (1.12.0)
     execjs (2.8.1)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
+    factory_bot (6.4.5)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     fancybox2-rails (0.2.7)
       railties (>= 3.1.0)
     ffaker (2.21.0)
@@ -293,7 +293,7 @@ DEPENDENCIES
   capybara
   coveralls
   database_cleaner
-  factory_girl_rails (~> 4.0)
+  factory_bot_rails
   fancybox2-rails
   ffaker
   formtastic

--- a/src/spec/controllers/admin/presenters_controller_spec.rb
+++ b/src/spec/controllers/admin/presenters_controller_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Admin::PresentersController do
 
-  let(:presenter) { FactoryGirl.create(:participant, name: 'John McCarthy', email: 'parens@example.org') }
-  let(:event) { FactoryGirl.create(:event) }
-  let!(:session) { FactoryGirl.create(:session, participant: presenter, event: event) }
+  let(:presenter) { FactoryBot.create(:participant, name: 'John McCarthy', email: 'parens@example.org') }
+  let(:event) { FactoryBot.create(:event) }
+  let!(:session) { FactoryBot.create(:session, participant: presenter, event: event) }
 
   describe "#index" do
     it "should be successful" do
@@ -43,9 +43,9 @@ describe Admin::PresentersController do
   end
 
   describe "#export_all" do
-    let(:older_event) { FactoryGirl.create(:event, date: 1.year.ago) }
-    let(:second_presenter) { FactoryGirl.create(:participant, name: 'Kristen Nygaard', email: 'objectify@example.org') }
-    let!(:second_session) { FactoryGirl.create(:session, participant: second_presenter, event: older_event) }
+    let(:older_event) { FactoryBot.create(:event, date: 1.year.ago) }
+    let(:second_presenter) { FactoryBot.create(:participant, name: 'Kristen Nygaard', email: 'objectify@example.org') }
+    let!(:second_session) { FactoryBot.create(:session, participant: second_presenter, event: older_event) }
 
     it "should be successful" do
       get :export_all

--- a/src/spec/factories.rb
+++ b/src/spec/factories.rb
@@ -15,7 +15,7 @@ SLOTS = ["09:40", "10:40", "11:40", "13:50", "14:50", "15:50", "16:50"]
 SESSION_LENGTH = 45.minutes
 
 
-FactoryGirl.define do
+FactoryBot.define do
 
   sequence :category_name do |n|
     CATEGORIES[n % CATEGORIES.length]

--- a/src/spec/factories/category.rb
+++ b/src/spec/factories/category.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :category do
-    name {generate :category_name}
+    name { generate :category_name }
   end
 
 end

--- a/src/spec/factories/event.rb
+++ b/src/spec/factories/event.rb
@@ -1,14 +1,15 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :event do
-
-    name "Minnebar"
-    date 30.days.since
+    sequence :name do |n|
+      "Minnebar #{n}"
+    end
+    date { 30.days.since }
 
     trait :full_event do
       transient do
-        rooms_count 9
-        timeslots_count 7
+        rooms_count { 9 }
+        timeslots_count { 7 }
       end
 
       after(:create) do |event, evaluator|

--- a/src/spec/factories/participant.rb
+++ b/src/spec/factories/participant.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :participant do
     sequence :name do |n|
@@ -6,21 +6,21 @@ FactoryGirl.define do
     end
 
     email { "#{name.gsub(/\s/, '_')}@example.com" }
-    password 'seekret!'
+    password { "seekret!" }
 
     factory :joe do
-      email "joe@example.com"
-      name "Joe Schmoe"
+      email { "joe@example.com" }
+      name { "Joe Schmoe" }
     end
 
     factory :luke do
-      email "look@recursion.org"
-      name 'Luke Francl'
-      github_profile_username "look"
-      github_og_image "https://avatars1.githubusercontent.com/u/10186?v=3&s=400"
-      github_og_url   "https://github.com/look"
-      twitter_handle  "lof"
-      bio 'the man with the master plan'
+      email { "look@recursion.org" }
+      name { "Luke Francl" }
+      github_profile_username { "look" }
+      github_og_image { "https://avatars1.githubusercontent.com/u/10186?v=3&s=400" }
+      github_og_url { "https://github.com/look" }
+      twitter_handle { "lof" }
+      bio { "the man with the master plan" }
     end
   end
 end

--- a/src/spec/factories/presenter_timeslot_restriction.rb
+++ b/src/spec/factories/presenter_timeslot_restriction.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :presenter_timeslot_restriction do
     association :participant
     association :timeslot
-    weight 1
+    weight { 1 }
   end
 end

--- a/src/spec/factories/room.rb
+++ b/src/spec/factories/room.rb
@@ -1,10 +1,10 @@
 
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :room do
     association :event
     name { generate :room_name }
-    capacity [100, 250, 60, 40, 24].sample
+    capacity { [100, 250, 60, 40, 24].sample }
   end
 
 end

--- a/src/spec/factories/session.rb
+++ b/src/spec/factories/session.rb
@@ -1,8 +1,10 @@
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :session do
-    title 'Stuff about things'
-    description 'whatever'
+    sequence :title do |n|
+      " Session #{n}"
+    end
+    description { 'whatever' }
     participant
     association :event
     association :room

--- a/src/spec/factories/timeslot.rb
+++ b/src/spec/factories/timeslot.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :timeslot do
     association :event
@@ -7,7 +7,7 @@ FactoryGirl.define do
     ends_at { starts_at + SESSION_LENGTH }
 
     factory :timeslot_1 do
-      title 'Session 1'
+      title { 'Session 1' }
       starts_at { Time.zone.parse("#{event.date.strftime('%Y-%m-%d')} 09:00:00") }
 
       ends_at { starts_at + 50.minutes }

--- a/src/spec/features/display_schedule_spec.rb
+++ b/src/spec/features/display_schedule_spec.rb
@@ -4,7 +4,7 @@ feature "Displaying the schedule" do
   let(:event) { create(:event, :full_event) }
 
   before do
-    create(:session, timeslot: event.timeslots.first, event: event)
+    create(:session, title: "Stuff about things", timeslot: event.timeslots.first, event: event)
   end
 
   scenario "should draw the schedule page" do

--- a/src/spec/models/timeslot_spec.rb
+++ b/src/spec/models/timeslot_spec.rb
@@ -10,8 +10,8 @@ describe Timeslot do
 
   context "#destroy" do
     it "destroys associated PresenterTimeslotRestrictions" do
-      timeslot = FactoryGirl.create(:timeslot)
-      FactoryGirl.create(:presenter_timeslot_restriction, timeslot: timeslot)
+      timeslot = FactoryBot.create(:timeslot)
+      FactoryBot.create(:presenter_timeslot_restriction, timeslot: timeslot)
 
       expect { timeslot.destroy }.to change { PresenterTimeslotRestriction.count }.by(-1)
     end

--- a/src/spec/spec_helper.rb
+++ b/src/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Authlogic::TestCase, type: :controller
   config.include AuthenticationSupport, type: :feature
 


### PR DESCRIPTION
`FactoryGirl` has been deprecated for a long time. This PR upgrades from `FactoryGirl` => `FactoryBot`.

* Switch from `factory_girl_rails` => `factory_bot_rails`
* Convert static attribute definitions to dynamic in factories (see https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11).