### PR TITLE
Update presentations controller logic and spec

### DIFF
--- a/src/app/controllers/presentations_controller.rb
+++ b/src/app/controllers/presentations_controller.rb
@@ -17,10 +17,7 @@ class PresentationsController < ApplicationController
       end
 
       if participant.nil?
-        message = participant_params[:name] ?
-          "Sorry, no presenter matching '#{participant_params[:name]}' was found. Please try again." :
-          "Sorry, no presenter was found. Please try again."
-        flash[:error] = message
+        flash[:error] = "Sorry, no presenter #{participant_params[:name] ? "matching '#{participant_params[:name]}' " : "" }was found. Please try again."
         redirect_to session_presentations_path(@session)
         return
       elsif participant.signed_code_of_conduct_for_current_event? == false

--- a/src/app/controllers/presentations_controller.rb
+++ b/src/app/controllers/presentations_controller.rb
@@ -9,27 +9,44 @@ class PresentationsController < ApplicationController
   end
 
   def create
-    participant = Participant.find(params[:id])
+    begin
+      participant = if participant_params[:id].present?
+        Participant.find(participant_params[:id])
+      elsif participant_params[:name].present?
+        participant = Participant.where(name: participant_params[:name])&.first
+      end
 
-    if participant.nil?
-      flash[:error] = "Sorry, no presenter named #{params[:name]} was found. Please try again."
+      if participant.nil?
+        message = participant_params[:name] ?
+          "Sorry, no presenter matching '#{participant_params[:name]}' was found. Please try again." :
+          "Sorry, no presenter was found. Please try again."
+        flash[:error] = message
+        redirect_to session_presentations_path(@session)
+        return
+      elsif participant.signed_code_of_conduct_for_current_event? == false
+        flash[:error] = "Sorry, #{participant.name} hasn't signed the current Code of Conduct."
+        redirect_to session_presentations_path(@session)
+        return
+      end
+
+      presentation = @session.presentations.new
+      presentation.participant = participant
+
+      if presentation.save
+        flash[:notice] = "Presenter added."
+        redirect_to session_presentations_path(@session)
+      else
+        raise StandardError
+      end
+    rescue => e
+      flash[:error] = "There was an error adding the presenter. Please try again. If this keeps happening, please contact support@minnestar.org."
       redirect_to session_presentations_path(@session)
-      return
-    elsif participant.signed_code_of_conduct_for_current_event? == false
-      flash[:error] = "Sorry, #{params[:name]} hasn't signed the current Code of Conduct."
-      redirect_to session_presentations_path(@session)
-      return
     end
+  end
 
-    presentation = @session.presentations.new
-    presentation.participant = participant
+  private
 
-    if presentation.save
-      flash[:notice] = "Presenter added."
-      redirect_to session_presentations_path(@session)
-    else
-      flash[:error] = "There was an error adding the presenter. Please try again. If this keeps happening, please contact luke@minnestar.org."
-      redirect_to session_presentations_path(@session)
-    end
+  def participant_params
+    params.permit(:session_id, :id, :name)
   end
 end

--- a/src/spec/controllers/presentations_controller_spec.rb
+++ b/src/spec/controllers/presentations_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe PresentationsController do
   let(:session) { create(:session) }
+  let(:participant) { create(:joe) }
 
   describe "#index" do
     it "should be successful" do
@@ -13,38 +14,68 @@ describe PresentationsController do
   end
 
   describe "#create" do
-    context "when the user exists" do
-      before do
-        create(:event)
-        create(:joe)
-      end
+    before do
+      create(:event)
+    end
 
+    context "when the user is found by id" do
       it "should be successful when the user has signed the code of conduct" do
         CodeOfConductAgreement.create!({
-          participant_id: Participant.where(name: 'Joe Schmoe').first.id,
+          participant_id: participant.id,
           event_id: Event.current_event.id,
         })
 
         expect {
-          post :create, params: { session_id: session, name: 'Joe Schmoe' }
+          post :create, params: { session_id: session, id: participant.id }
         }.to change { session.presentations.count }.by(1)
         expect(response).to redirect_to session_presentations_path(session)
         expect(flash[:notice]).to eq "Presenter added."
       end
 
       it 'is unsuccessful when the user hasnt signed the code of conduct' do
-        post :create, params: { session_id: session, name: 'Joe Schmoe' }
+        post :create, params: { session_id: session, id: participant.id }
         expect(response).to redirect_to session_presentations_path(session)
-        expect(flash[:error]).to match(/hasn\'t signed the Code of Conduct for this event/)
+        expect(flash[:error]).to match(/hasn\'t signed the current Code of Conduct/)
       end
     end
 
-    context "when the user is not found" do
+    context "when the user is found by name" do
+      it "should be successful when the user has signed the code of conduct" do
+        CodeOfConductAgreement.create!({
+          participant_id: participant.id,
+          event_id: Event.current_event.id,
+        })
+
+        expect {
+          post :create, params: { session_id: session, name: participant.name }
+        }.to change { session.presentations.count }.by(1)
+        expect(response).to redirect_to session_presentations_path(session)
+        expect(flash[:notice]).to eq "Presenter added."
+      end
+
+      it 'is unsuccessful when the user hasnt signed the code of conduct' do
+        post :create, params: { session_id: session, name: participant.name }
+        expect(response).to redirect_to session_presentations_path(session)
+        expect(flash[:error]).to match(/hasn\'t signed the current Code of Conduct/)
+      end
+    end
+
+    context "when the user name is not found" do
       it "should set a flash message" do
         expect {
           post :create, params: { session_id: session, name: 'Grace Hopper' }
         }.not_to change { session.presentations.count }
-        expect(flash[:error]).to eq "Sorry, no presenter named 'Grace Hopper' was found. Please try again."
+        expect(flash[:error]).to eq "Sorry, no presenter matching 'Grace Hopper' was found. Please try again."
+        expect(response).to redirect_to session_presentations_path(session)
+      end
+    end
+
+    context "when the user id is not found" do
+      it "should set a flash message" do
+        expect {
+          post :create, params: { session_id: session, id: 0 }
+        }.not_to change { session.presentations.count }
+        expect(flash[:error]).to eq "There was an error adding the presenter. Please try again. If this keeps happening, please contact support@minnestar.org."
         expect(response).to redirect_to session_presentations_path(session)
       end
     end


### PR DESCRIPTION
This is a follow up to https://github.com/minnestar/sessionizer/pull/305, which broke the controller tests.

This allows for both `:id` and `:name` params to be passed into the controller. When a presenter is found, an `:id` is passed, but if the user hits enter with just a text string search, we still need to handle that case, hence why `:name` is still permitted.