### PR TITLE
Confirm participant emails

### DIFF
--- a/app/assets/stylesheets/shared.css.scss
+++ b/app/assets/stylesheets/shared.css.scss
@@ -74,7 +74,7 @@ a {
   margin-top: 20px;
 }
 
-#flash_notice, #flash_error {
+#flash_notice, #flash_error, #flash_alert {
   padding: 5px 8px;
   margin: 10px 0;
 }
@@ -87,6 +87,11 @@ a {
 #flash_error {
   background-color: #FCC;
   border: solid 1px #C66;
+}
+
+#flash_alert {
+  background-color: #FEC;
+  border: solid 1px #E96;
 }
 
 .fieldWithErrors {

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -19,7 +19,7 @@ class AttendancesController < ApplicationController
       respond_to do |format|
         # Appears after the user logs in by clicking on “Yes! I might attend” while logged out
         format.html do
-          flash[:notice] = "Thanks for your interest in this session."
+          flash[:notice] = "Thanks for your interest in this session. Please check your email to confirm your account."
           redirect_to @session
         end
 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -74,7 +74,7 @@ class ParticipantsController < ApplicationController
   def send_confirmation_email
     @participant.deliver_email_confirmation_instructions!
     flash[:notice] = "Confirmation instructions sent! Please check your email."
-    redirect_to @participant
+    redirect_to participant_path(@participant)
   end
 
   def confirm_email

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -1,6 +1,6 @@
 class ParticipantsController < ApplicationController
   respond_to :html
-  load_resource
+  load_resource except: :confirm_email
   before_action :verify_owner, :only => [:edit, :update]
 
   def index
@@ -24,6 +24,7 @@ class ParticipantsController < ApplicationController
   end
 
   def update
+    # TODO: Check if email address was changed. If so, clear out email_confirmed_at
     @participant.update(participant_params.except(:code_of_conduct_agreement))
     create_code_of_conduct_agreement_if_not_exists!
     respond_with(@participant)
@@ -33,10 +34,11 @@ class ParticipantsController < ApplicationController
     @participant.attributes = participant_params.except(:code_of_conduct_agreement)
     if @participant.save
       create_code_of_conduct_agreement_if_not_exists!
-      flash[:notice] = "Thanks for registering an account. You may now create sessions and mark sessions you'd like to attend."
+      @participant.deliver_email_confirmation_instructions!
+      flash[:notice] = "Thanks for registering an account. Please check your email to confirm your account."
       redirect_to root_path
     else
-      flash[:error] = "There was a problem creating that account."
+      flash[:error] = "There was a problem creating your account."
       render :new
     end
   end
@@ -47,6 +49,24 @@ class ParticipantsController < ApplicationController
         participant_id: @participant.id,
         event_id: Event.current_event.id,
       })
+    end
+  end
+
+  def send_confirmation_email
+    @participant.deliver_email_confirmation_instructions!
+    flash[:notice] = "Confirmation instructions sent! Please check your email."
+    redirect_to @participant
+  end
+
+  def confirm_email
+    # TODO: load participant by perishable token
+    @participant = Participant.find_using_perishable_token(params[:token])
+    if @participant.confirm_email!
+      flash[:notice] = "Email confirmed. Thank you!"
+      redirect_to root_path
+    else
+      flash[:error] = "Something went wrong. Please try again."
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -1,4 +1,6 @@
 class ParticipantsController < ApplicationController
+  include ParticipantsHelper
+
   respond_to :html
   load_resource except: :confirm_email
   before_action :verify_owner, :only => [:edit, :update]
@@ -16,10 +18,16 @@ class ParticipantsController < ApplicationController
   end
 
   def show
+    unless @participant.email_confirmed?
+      flash[:alert] = email_confirmation_alert(@participant)
+    end
     respond_with(@participant)
   end
 
   def edit
+    unless @participant.email_confirmed?
+      flash[:alert] = email_confirmation_alert(@participant)
+    end
     respond_with(@participant)
   end
 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -59,7 +59,6 @@ class ParticipantsController < ApplicationController
   end
 
   def confirm_email
-    # TODO: load participant by perishable token
     @participant = Participant.find_using_perishable_token(params[:token])
     if @participant.confirm_email!
       flash[:notice] = "Email confirmed. Thank you!"

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -32,10 +32,21 @@ class ParticipantsController < ApplicationController
   end
 
   def update
-    # TODO: Check if email address was changed. If so, clear out email_confirmed_at
-    @participant.update(participant_params.except(:code_of_conduct_agreement))
-    create_code_of_conduct_agreement_if_not_exists!
-    respond_with(@participant)
+    new_params = participant_params.except(:code_of_conduct_agreement)
+
+    # reset email_confirmed_at if the email address was changed
+    if (new_params[:email] != @participant.email)
+      @participant.email_confirmed_at = nil
+    end
+
+    if @participant.update(new_params)
+      create_code_of_conduct_agreement_if_not_exists!
+      flash[:notice] = "Profile updated successfully."
+      redirect_to participant_path(@participant)
+    else
+      flash[:error] = "There was a problem updating your profile."
+      render :edit
+    end
   end
 
   def create
@@ -88,6 +99,6 @@ class ParticipantsController < ApplicationController
   end
 
   def verify_owner
-    redirect_to @participant if @participant != current_participant
+    redirect_to participant_path(@participant) if @participant != current_participant
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 class SessionsController < ApplicationController
-
   load_resource only: [:new, :show, :edit, :create, :update, :destroy]
   before_action :authenticate_participant, only: [:new, :create, :update, :edit, :destroy]
   before_action :verify_owner, only: [:update, :edit, :destroy]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 class SessionsController < ApplicationController
+
   load_resource only: [:new, :show, :edit, :create, :update, :destroy]
   before_action :authenticate_participant, only: [:new, :create, :update, :edit, :destroy]
   before_action :verify_owner, only: [:update, :edit, :destroy]

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,7 @@
 class UserSessionsController < ApplicationController
+  # needed to use a link_to for the "Confirm your email" flash message
+  include ActionView::Helpers::UrlHelper
+
   def new
     if params[:after_login]
       session[:after_login] = params[:after_login]
@@ -9,7 +12,12 @@ class UserSessionsController < ApplicationController
   def create
     @participant_session = ParticipantSession.new(participant_session_params.to_h)
     if @participant_session.save
-      flash[:notice] = "You're logged in. Welcome back."
+      participant = @participant_session.participant
+      if participant.email_confirmed?
+        flash[:notice] = "You're logged in. Welcome back."
+      else
+        flash[:notice] = "Your email has not been confirmed. Please #{link_to 'Confirm your email', send_confirmation_email_participant_path(participant), method: :post}".html_safe
+      end
       redirect_to session[:after_login] || root_path
       session.delete(:after_login)
     else

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,5 @@
 class UserSessionsController < ApplicationController
-  # needed to use a link_to for the "Confirm your email" flash message
-  include ActionView::Helpers::UrlHelper
+  include ParticipantsHelper
 
   def new
     if params[:after_login]
@@ -16,7 +15,7 @@ class UserSessionsController < ApplicationController
       if participant.email_confirmed?
         flash[:notice] = "You're logged in. Welcome back."
       else
-        flash[:notice] = "Your email has not been confirmed. Please #{link_to 'Confirm your email', send_confirmation_email_participant_path(participant), method: :post}".html_safe
+        flash[:alert] = email_confirmation_alert(participant)
       end
       redirect_to session[:after_login] || root_path
       session.delete(:after_login)

--- a/app/helpers/participants_helper.rb
+++ b/app/helpers/participants_helper.rb
@@ -1,0 +1,11 @@
+module ParticipantsHelper
+  include ActionView::Helpers::UrlHelper
+
+  def email_confirmation_link(participant)
+    link_to "Confirm your email", send_confirmation_email_participant_path(participant), method: :post
+  end
+
+  def email_confirmation_alert(participant)
+    "Your email has not been confirmed. Please #{email_confirmation_link(participant)}.".html_safe
+  end
+end 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,11 +1,15 @@
 class Notifier < ActionMailer::Base
-  default from: 'support@minnestar.org',  
+  default from: "support@minnestar.org",
           content_type: "text/html"
 
-  def password_reset_instructions(user)
-    @user = user
+  def password_reset_instructions(participant)
+    @participant = participant
     @sent_on = Time.now
-    mail(to: @user.email, subject: 'Password Reset Instructions')
+    mail(to: @participant.email, subject: "Password Reset Instructions")
   end
 
+  def participant_email_confirmation(participant)
+    @participant = participant
+    mail(to: participant.email, subject: "Please confirm your email")
+  end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -82,6 +82,20 @@ class Participant < ActiveRecord::Base
   def self.find_by_case_insensitive_email(email)
     where(['lower(email) = ?', email.to_s.downcase]).first
   end
+
+  def email_confirmed?
+    !!self.email_confirmed_at
+  end
+
+  def deliver_email_confirmation_instructions!
+    reset_perishable_token!
+    Notifier.participant_email_confirmation(self).deliver_now!
+  end
+
+  def confirm_email!
+    self.email_confirmed_at = Time.now
+    save!
+  end
 end
 
 

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -17,6 +17,8 @@ class Participant < ActiveRecord::Base
     config.require_password_confirmation = false
   end
 
+  scope :confirmed, -> { where.not(email_confirmed_at: nil) }
+
   def restrict_after(datetime, weight=1, event=Event.current_event)
     event.timeslots.each do |timeslot|
       if timeslot.ends_at > datetime

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,7 @@
       <div class="page-heading">
         <div class="clear"></div>
         <div id="flash_message_placeholder"></div>
-        <%- [:error, :notice, :success].each do |name| -%>
+        <%- [:error, :notice, :success, :alert].each do |name| -%>
           <%= content_tag :div, flash[name], :id => "flash_#{name}" if flash[name] %>
         <%- end -%>
 

--- a/app/views/notifier/participant_email_confirmation.html.erb
+++ b/app/views/notifier/participant_email_confirmation.html.erb
@@ -1,0 +1,5 @@
+<h2>Confirm your email</h2>
+
+<p>Please confirm your email by clicking the link below:</p>
+
+<p><%= link_to "Confirm my email", confirm_email_participant_url(@participant, token: @participant.perishable_token) %></p>

--- a/app/views/notifier/password_reset_instructions.html.erb
+++ b/app/views/notifier/password_reset_instructions.html.erb
@@ -6,4 +6,4 @@
   request, please follow the link below.
 </p>
 
-<%= link_to "Reset Password!", edit_password_reset_url(@user.perishable_token) %>
+<%= link_to "Reset Password!", edit_password_reset_url(@participant.perishable_token) %>

--- a/app/views/participants/edit.html.erb
+++ b/app/views/participants/edit.html.erb
@@ -3,9 +3,17 @@
 <%= semantic_form_for(@participant) do |f| %>
   <%= f.semantic_errors %>
 
+  <% email_hint = "Please use a real email address. We need this to contact you about your presentation." %>
+
   <%= f.inputs do %>
     <%= f.input :name, :label => 'Your name', :hint => "Please use your real name. This will be used in our printed materials." %>
-    <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
+    <%= f.input :email,
+      :label => 'Your email',
+      # TODO: Figure out how to get "Confirm your email" link to be displayed inline next to the email input
+      :hint => @participant.email_confirmed? ?
+        email_hint :
+        "#{link_to "Confirm your email", send_confirmation_email_participant_path(@participant), method: :post}<br />#{email_hint}".html_safe
+      %>
     <%= f.input :github_profile_username, :label => 'Your GitHub username' %>
     <%= f.input :twitter_handle, :label => 'Your Twitter handle' %>
     <%= f.input :bio, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <strong>**bold**</strong>, <em>*italic*</em>, [link](http://example.com)'.html_safe %>

--- a/app/views/participants/edit.html.erb
+++ b/app/views/participants/edit.html.erb
@@ -5,7 +5,7 @@
 
   <%= f.inputs do %>
     <%= f.input :name, :label => 'Your name', :hint => "Please use your real name. This will be used in our printed materials." %>
-<%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
+    <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
     <%= f.input :github_profile_username, :label => 'Your GitHub username' %>
     <%= f.input :twitter_handle, :label => 'Your Twitter handle' %>
     <%= f.input :bio, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <strong>**bold**</strong>, <em>*italic*</em>, [link](http://example.com)'.html_safe %>

--- a/app/views/participants/edit.html.erb
+++ b/app/views/participants/edit.html.erb
@@ -3,17 +3,9 @@
 <%= semantic_form_for(@participant) do |f| %>
   <%= f.semantic_errors %>
 
-  <% email_hint = "Please use a real email address. We need this to contact you about your presentation." %>
-
   <%= f.inputs do %>
     <%= f.input :name, :label => 'Your name', :hint => "Please use your real name. This will be used in our printed materials." %>
-    <%= f.input :email,
-      :label => 'Your email',
-      # TODO: Figure out how to get "Confirm your email" link to be displayed inline next to the email input
-      :hint => @participant.email_confirmed? ?
-        email_hint :
-        "#{link_to "Confirm your email", send_confirmation_email_participant_path(@participant), method: :post}<br />#{email_hint}".html_safe
-      %>
+<%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
     <%= f.input :github_profile_username, :label => 'Your GitHub username' %>
     <%= f.input :twitter_handle, :label => 'Your Twitter handle' %>
     <%= f.input :bio, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <strong>**bold**</strong>, <em>*italic*</em>, [link](http://example.com)'.html_safe %>

--- a/app/views/sessions/_email_confirmation.html.erb
+++ b/app/views/sessions/_email_confirmation.html.erb
@@ -1,0 +1,15 @@
+<br />
+<p>
+  To mitigate spam, you must confirm your email before you'll be able to create a session. 
+  Please click the link below to confirm your email address. Thanks!
+</p>
+<br />
+
+<%= link_to "Send Confirmation Instructions",
+send_confirmation_email_participant_path(current_participant), method: :post,
+class: "button" %>
+
+<br /><br />
+<p>
+  Please contact us at <a href="mailto:support@minnestar.org">support@minnestar.org</a> if you have any questions.
+</p>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,8 +1,12 @@
-<% title('New Session') %>
-
 <% if Settings.allow_new_sessions? %>
-    <p><strong>Note: sessions can be at most 50 minutes long.</strong>
+  <% if current_participant.email_confirmed? %>
+    <% title('New Session') %>
+    <p><strong>Note: sessions can be at most 45 minutes long.</strong></p>
     <%= render 'form' %>
+  <% else %>
+    <% title('Email Confirmation Required') %>
+    <%= render 'email_confirmation' %>
+  <% end %>
 <% else %>
-    <p>Sorry, session submission is now closed for <%= Event.current_event.name %>.</p>
+  <p>Sorry, session submission is now closed for <%= Event.current_event.name %>.</p>
 <% end %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -60,7 +60,7 @@
   </div>
 
   <% if @session.event.current? %>
-    <div class="column grid_4" style="float: right">
+    <div class="column grid_4" style="float: right; padding-left: 5px;">
 
       <div id="interested-in-attending" class="interested-in-attending">
         <% if !@session.attending?(current_participant) %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -73,13 +73,13 @@
         <% end %>
       </div>
 
-      <% if @session.participants.any? %>
+      <% if @session.participants.confirmed.any? %>
         <h3>Interested Participants</h3>
       <% else %>
         <h3 id="no-participants">No participants yet</h3>
       <% end %>
       <ul class="sessionsList" id="participants">
-        <%= render :partial => 'participant', :collection => @session.participants %>
+        <%= render :partial => 'participant', :collection => @session.participants.confirmed %>
       </ul>
 
     </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = false
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_options = {from: "no-reply@#{HOST}" }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
 
   # Raises error for missing translations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Sessionizer::Application.routes.draw do
   end
 
   get '/attendances' => 'attendances#index'
-  resources :participants, :except => [:destroy]
+  resources :participants, :except => [:destroy] do
+    member do
+      post :send_confirmation_email
+      get :confirm_email
+    end
+  end
   resources :categories, only: :show
 
   match '/login' => 'user_sessions#new', :as => :new_login, :via => 'get'

--- a/db/migrate/20250209180413_add_email_confirmed_at_to_participants.rb
+++ b/db/migrate/20250209180413_add_email_confirmed_at_to_participants.rb
@@ -1,0 +1,5 @@
+class AddEmailConfirmedAtToParticipants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :participants, :email_confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_151346) do
+ActiveRecord::Schema.define(version: 2025_02_09_180413) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "attendances", id: :serial, force: :cascade do |t|
@@ -78,6 +79,7 @@ ActiveRecord::Schema.define(version: 2020_09_29_151346) do
     t.string "github_og_image"
     t.string "github_og_url"
     t.string "twitter_handle"
+    t.datetime "email_confirmed_at"
     t.index ["email"], name: "index_participants_on_email", unique: true
     t.index ["perishable_token"], name: "index_participants_on_perishable_token"
   end

--- a/spec/controllers/attendances_controller_spec.rb
+++ b/spec/controllers/attendances_controller_spec.rb
@@ -19,7 +19,7 @@ describe AttendancesController do
               post :create, params: {session_id: session}
             }.to change { session.attendances.count }.by(1)
             expect(response).to redirect_to session
-            expect(flash[:notice]).to eq "Thanks for your interest in this session."
+            expect(flash[:notice]).to eq "Thanks for your interest in this session. Please check your email to confirm your account."
           end
         end
 
@@ -68,7 +68,7 @@ describe AttendancesController do
                                     }
             }.to change { session.attendances.count }.by(1)
             expect(response).to redirect_to session
-            expect(flash[:notice]).to eq "Thanks for your interest in this session."
+            expect(flash[:notice]).to eq "Thanks for your interest in this session. Please check your email to confirm your account."
           end
         end
       end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -83,7 +83,7 @@ describe ParticipantsController do
     describe "#update" do
       it "should be successful" do
         put :update, params: {id: joe, participant: { name: 'schmoe, joe' }}
-        expect(response).to redirect_to joe
+        expect(response).to redirect_to participant_path(joe)
         expect(joe.reload.name).to eq 'schmoe, joe'
       end
 
@@ -96,6 +96,14 @@ describe ParticipantsController do
           expect(response).to be_redirect
           expect(joe.reload.twitter_handle).to eq 'schmoe'
           expect(joe.github_profile_username).to eq 'jschmoe'
+        end
+      end
+
+      describe "when email address is changed" do
+        it "should unconfirm the user's email" do
+          put :update, params: {id: joe, participant: { email: 'new@example.org',}}
+          expect(response).to be_redirect
+          expect(joe.reload.email_confirmed_at).to be_nil
         end
       end
     end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -30,7 +30,7 @@ describe ParticipantsController do
                              }
       }
       expect(response).to redirect_to root_path
-      expect(flash[:notice]).to eq "Thanks for registering an account. You may now create sessions and mark sessions you'd like to attend."
+      expect(flash[:notice]).to eq "Thanks for registering an account. Please check your email to confirm your account."
     end
   end
 

--- a/spec/features/interest_gathering_spec.rb
+++ b/spec/features/interest_gathering_spec.rb
@@ -3,7 +3,8 @@ require "spec_helper"
 feature "Gauging interest in a session" do
 
   let(:event) { create(:event, :full_event) }
-  let(:user) { create(:participant, name: 'Hedy Lamarr', email: 'freq-hopper@example.org') }
+  let(:confirmed_user) { create(:participant, name: 'Hedy Lamarr', email: 'freq-hopper@example.org', email_confirmed_at: Time.now) }
+  let(:unconfirmed_user) { create(:participant, email_confirmed_at: nil) }
 
   background do
     create(:session, title: "A neat talk", event: event)
@@ -20,13 +21,22 @@ feature "Gauging interest in a session" do
     fill_in "Password", with: "c4ever!!!!!!!!!"
     click_button "Create Account"
 
-    expect(page).to have_content 'Thanks for your interest in this session.'
-    expect(page).to have_selector 'ul#participants li', text: 'Dennis Ritchie'
+    expect(page).to have_content 'Thanks for your interest in this session. Please check your email to confirm your account.'
+    expect(page).to have_content 'No participants yet'
   end
 
+  scenario "As a signed in unconfirmed user I want to express my interest", js: true, unless: ENV['CI'] do
+    sign_in_user unconfirmed_user
 
-  scenario "As a signed in user I want to express my interest", js: true, unless: ENV['CI'] do
-    sign_in_user user
+    click_link "A neat talk", match: :first
+    page.find("#attend").click
+
+    expect(page).to have_content 'Thanks for your interest in this session.'
+    expect(page).to have_content 'No participants yet'
+  end
+
+  scenario "As a signed in confirmed user I want to express my interest", js: true, unless: ENV['CI'] do
+    sign_in_user confirmed_user
 
     click_link "A neat talk", match: :first
     page.find("#attend").click

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -44,7 +44,7 @@ feature "Manage Sessions" do
 
     click_link "Add Session", match: :first
 
-    expect(page).to have_content("Email confirmation Required")
+    expect(page).to have_content(/email confirmation required/i)
     expect(page).to have_link("Send Confirmation Instructions")
     expect(page).not_to have_button("Update Session")
   end

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -44,7 +44,8 @@ feature "Manage Sessions" do
 
     click_link "Add Session", match: :first
 
-    expect(page).to have_content "Please Confirm your email before creating a session."
-    expect(page).to have_button('Update Session', disabled: true)
+    expect(page).to have_content("Email confirmation Required")
+    expect(page).to have_link("Send Confirmation Instructions")
+    expect(page).not_to have_button("Update Session")
   end
 end

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -5,7 +5,33 @@ feature "Manage Sessions" do
     create(:event, :full_event)
   end
 
-  scenario "As a guest, I want to register " do
+  scenario "As a new user, I want to register and add a session" do
+    visit root_path
+
+    click_link "Add Session", match: :first
+    click_link "Register here"
+
+    fill_in 'participant_name', with: 'Jack Johnson'
+    fill_in 'Your email', with: 'jack@example.com'
+    fill_in 'Password', with: 's00persekret12345'
+    click_button "Create My Account"
+
+    # Open the email confirmation link
+    email = ActionMailer::Base.deliveries.last
+    confirmation_link = email.body.match(/href="([^"]+)/)[1]
+    visit confirmation_link
+
+    visit root_path
+    click_link "Add Session", match: :first
+
+    fill_in('Title', with: 'Rails 4 FTW')
+    fill_in('Description', with: 'Rails Desc')
+
+    click_button 'Update Session'
+    expect(page).to have_content 'Thanks for adding your session.'
+  end
+
+  scenario "As a new user, I cannot add a session until my email has been confirmed" do
     visit root_path
 
     click_link "Add Session", match: :first
@@ -18,10 +44,7 @@ feature "Manage Sessions" do
 
     click_link "Add Session", match: :first
 
-    fill_in('Title', with: 'Rails 4 FTW')
-    fill_in('Description', with: 'Rails Desc')
-
-    click_button 'Update Session'
-    expect(page).to have_content 'Thanks for adding your session.'
+    expect(page).to have_content "Please Confirm your email before creating a session."
+    expect(page).to have_button('Update Session', disabled: true)
   end
 end

--- a/spec/features/manage_your_profile_spec.rb
+++ b/spec/features/manage_your_profile_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 feature "Manage a user profile" do
 
-  context "As an authenticated user" do
-    let(:joe) { create(:joe) }
+  context "As an authenticated user without a confirmed email" do
+    let(:joe) { create(:joe, email_confirmed_at: Time.now) }
     background do
       create(:event)
       sign_in_user(joe)
@@ -23,6 +23,5 @@ feature "Manage a user profile" do
       expect(page).to have_content bio
     end
   end
-
 end
 

--- a/spec/features/manage_your_profile_spec.rb
+++ b/spec/features/manage_your_profile_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 feature "Manage a user profile" do
 
-  context "As an authenticated user without a confirmed email" do
+  context "As an authenticated user" do
     let(:joe) { create(:joe, email_confirmed_at: Time.now) }
     background do
       create(:event)
@@ -23,5 +23,6 @@ feature "Manage a user profile" do
       expect(page).to have_content bio
     end
   end
+
 end
 

--- a/spec/features/sign_in_and_out_spec.rb
+++ b/spec/features/sign_in_and_out_spec.rb
@@ -44,7 +44,7 @@ feature "Authentication and account creation things" do
       check 'Remember me'
       click_button "Log in"
 
-      expect(page).to have_content "Your email has not been confirmed. Please Confirm your email"
+      expect(page).to have_content "Your email has not been confirmed. Please Confirm your email."
 
       click_link "Log out"
 

--- a/spec/features/sign_in_and_out_spec.rb
+++ b/spec/features/sign_in_and_out_spec.rb
@@ -1,69 +1,89 @@
 require "spec_helper"
 
 feature "Authentication and account creation things" do
+  let(:confirmed_email_user) { create(:participant, email_confirmed_at: Time.now) }
+  let(:unconfirmed_email_user) { create(:participant) }
 
-  let(:user) { create(:participant) }
+  describe "login" do
+    scenario "As a user who doesn't have an account" do
+      visit root_url
 
-  scenario "As a user who doesn't have an account" do
-    visit root_url
+      click_link "Log in"
 
-    click_link "Log in"
+      fill_in 'Email', with: 'bob@example.com'
+      fill_in 'Password', with: 'bobzurunkle!!!'
+      click_button "Log in"
 
-    fill_in 'Email', with: 'bob@example.com'
-    fill_in 'Password', with: 'bobzurunkle!!!'
-    click_button "Log in"
+      expect(page).to have_content "Sorry, couldn't find that participant. Try again, or sign up to register a new account."
+    end
 
-    expect(page).to have_content "Sorry, couldn't find that participant. Try again, or sign up to register a new account."
+    scenario "As a user with a confirmed email I want to sign in and out" do
+      visit root_path
+
+      click_link "Log in"
+
+      fill_in 'Email', with: confirmed_email_user.email
+      fill_in 'Password', with: confirmed_email_user.password
+      check 'Remember me'
+      click_button "Log in"
+
+      expect(page).to have_content "You're logged in. Welcome back."
+
+      click_link "Log out"
+
+      expect(page).to have_content "You have been logged out."
+    end
+
+    scenario "As a user with an unconfirmed email I want to sign in and out" do
+      visit root_path
+
+      click_link "Log in"
+
+      fill_in 'Email', with: unconfirmed_email_user.email
+      fill_in 'Password', with: unconfirmed_email_user.password
+      check 'Remember me'
+      click_button "Log in"
+
+      expect(page).to have_content "Your email has not been confirmed. Please Confirm your email"
+
+      click_link "Log out"
+
+      expect(page).to have_content "You have been logged out."
+    end
   end
 
-  scenario "As a user with an account, I want to sign in and out" do
-    visit root_path
+  describe "registration" do
+    scenario "As a user I can register a new account" do
+      visit root_path
 
-    click_link "Log in"
+      click_link "Log in"
+      click_link 'Register here'
 
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
-    check 'Remember me'
-    click_button "Log in"
+      name = FFaker::Name.name
+      fill_in 'Your name*', with: name
+      fill_in 'Your email', with: FFaker::Internet.safe_email
+      fill_in 'Password',  with: "anything, it doesnt matter"
+      click_button "Create My Account"
 
-    expect(page).to have_content "You're logged in. Welcome back."
+      expect(page).to have_content "Thanks for registering an account. Please check your email to confirm your account."
+      expect(page).to have_content "Welcome #{name}"
+    end
 
-    click_link "Log out"
+    scenario "As a user I try to register a new account with an already taken email address" do
+      visit root_path
 
-    expect(page).to have_content "You have been logged out."
-  end
+      click_link "Log in"
+      click_link 'Register here'
 
-  scenario "As a user I can register a new account" do
-    visit root_path
+      fill_in 'Your name*', with: confirmed_email_user.name
+      fill_in 'Your email', with: confirmed_email_user.email
+      fill_in 'Password', with: "anything, it doesnt matter"
+      click_button "Create My Account"
 
-    click_link "Log in"
-    click_link 'Register here'
-
-    name = FFaker::Name.name
-    fill_in 'Your name*', with: name
-    fill_in 'Your email', with: FFaker::Internet.safe_email
-    fill_in 'Password',  with: "anything, it doesnt matter"
-    click_button "Create My Account"
-
-    expect(page).to have_content "Thanks for registering an account. You may now create sessions and mark sessions you'd like to attend"
-    expect(page).to have_content "Welcome #{name}"
-  end
-
-  scenario "As a user I try to register a new account with an already taken email address" do
-    visit root_path
-
-    click_link "Log in"
-    click_link 'Register here'
-
-    name = FFaker::Name.name
-    fill_in 'Your name*', with: user.name
-    fill_in 'Your email', with: user.email
-    fill_in 'Password', with: "anything, it doesnt matter"
-    click_button "Create My Account"
-
-    expect(page).to have_content "There was a problem creating that account."
-    within("#participant_email_input") do
-      expect(page).to have_content "has already been taken"
+      expect(page).to have_content "There was a problem creating your account."
+      within("#participant_email_input") do
+        expect(page).to have_content "has already been taken"
+      end
     end
   end
 end

--- a/spec/support/authentication_support.rb
+++ b/spec/support/authentication_support.rb
@@ -10,7 +10,10 @@ module AuthenticationSupport
     fill_in 'Password', with: user.password
     click_button "Log in"
 
-    expect(page).to have_content "You're logged in. Welcome back."
+    expected_message = user.email_confirmed? ?
+      "You're logged in. Welcome back." :
+      "Your email has not been confirmed. Please Confirm your email."
+    expect(page).to have_content expected_message
 
   end
 


### PR DESCRIPTION
This is part of a larger effort to mitigate and prevent spam on the platform.

- [x] Add `email_confirmed_at` field & helper methods to `Participant` model
- [x] Add `ParticipantsController#send_confirmation_email` and `#confirm_email` endpoints 
- [x] Add `Notifier#participant_email_confirmation` and views for the confirmation email
- [x] Send `participant_email_confirmation` email after signup
- [x] Show "Confirm your email" flash message in various situations (login, edit participant, show participant) if email has not been confirmed
- [x] Don't allow users to create new sessions if email has not been confirmed
- [x] Don't show unconfirmed participants on the session show page 
- [x] Clear `email_confirmed_at` when user updates their email address
- Other small changes
    - Add support for `flash[:alert]` (orange)
    - Change `@user` references to `@participant` for consistency
    - Update tests & add test cases for new functionality
    - Update `respond_with(@participant` references due to collisions with URL helpers


## Demos of new functionality

### Existing user with unconfirmed email

https://github.com/user-attachments/assets/70c01750-30e4-4bb7-94bd-3c04b8796715


### New user signup

https://github.com/user-attachments/assets/abbea11b-05a6-45b9-b9b2-6cd9f1ea09b2


### Add session with unconfirmed email

https://github.com/user-attachments/assets/d2ac8b80-02f6-4a9a-8f88-6e9b08a887f9
