### PR TITLE
[#296] adds mastodon_url, bluesky_handle to participant socials

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -56,7 +56,8 @@ class ParticipantsController < ApplicationController
     params.require(controller_name.singularize).permit(
       :name, :email, :password,
       :bio, :github_profile_username,
-      :twitter_handle, :code_of_conduct_agreement
+      :twitter_handle, :mastodon_url, 
+      :bluesky_handle,:code_of_conduct_agreement
     )
   end
 

--- a/app/models/sessions_json_builder.rb
+++ b/app/models/sessions_json_builder.rb
@@ -6,6 +6,8 @@ class SessionsJsonBuilder
       participant_id: s.participant.id,
       presenter_name: s.participant.name,
       presenter_twitter_handle: s.participant.twitter_handle,
+      presenter_mastodon_url: s.participant.mastodon_url,
+      presenter_bluesky_handle: s.participant.bluesky_handle,
       presenter_github_username: s.participant.github_profile_username,
       presenter_github_og_image: s.participant.github_og_image,
       presenter_bio: s.participant.bio,

--- a/app/views/participants/edit.html.erb
+++ b/app/views/participants/edit.html.erb
@@ -6,8 +6,10 @@
   <%= f.inputs do %>
     <%= f.input :name, :label => 'Your name', :hint => "Please use your real name. This will be used in our printed materials." %>
     <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
-    <%= f.input :github_profile_username, :label => 'Your GitHub username' %>
-    <%= f.input :twitter_handle, :label => 'Your Twitter handle' %>
+    <%= f.input :github_profile_username, :label => 'Your GitHub username (optional)' %>
+    <%= f.input :twitter_handle, :label => 'Your Twitter (X) handle (optional)' %>
+    <%= f.input :mastodon_url, :label => 'Your Mastodon URL (optional)' %>
+    <%= f.input :bluesky_handle, :label => 'Your Bluesky handle (optional)' %>
     <%= f.input :bio, :hint => 'You can use <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a> syntax here. Examples: <strong>**bold**</strong>, <em>*italic*</em>, [link](http://example.com)'.html_safe %>
     <%=
       f.input :code_of_conduct_agreement,

--- a/app/views/participants/show.html.erb
+++ b/app/views/participants/show.html.erb
@@ -20,6 +20,20 @@
       <div>@<%= @participant.twitter_handle %></div>
     </div>
   <% end %>
+
+  <% if @participant.mastodon_url.present? %>
+    <div class="grid_3 column">
+      <h4>Mastodon:</h4>
+      <div><%= @participant.mastodon_url %></div>
+    </div>
+  <% end %>
+
+  <% if @participant.bluesky_handle.present? %>
+    <div class="grid_3 column">
+      <h4>Bluesky:</h4>
+      <div>@<%= @participant.bluesky_handle %></div>
+    </div>
+  <% end %>
 </div>
 
 <div class="row bio">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,6 +78,8 @@ ActiveRecord::Schema.define(version: 2020_09_29_151346) do
     t.string "github_og_image"
     t.string "github_og_url"
     t.string "twitter_handle"
+    t.string "mastodon_url"
+    t.string "bluesky_handle"
     t.index ["email"], name: "index_participants_on_email", unique: true
     t.index ["perishable_token"], name: "index_participants_on_perishable_token"
   end


### PR DESCRIPTION
Closes #296 

I also added the X to twitter and marked all socials as optional

See below:

<img width="1063" alt="Screenshot 2025-02-16 at 8 34 19 PM" src="https://github.com/user-attachments/assets/ec377681-ef66-400a-be58-33beac075867" />


<img width="934" alt="Screenshot 2025-02-16 at 8 34 03 PM" src="https://github.com/user-attachments/assets/e0238867-2478-4643-90cf-617ab64fbe3e" />

I'm not sure if I was meant to add db migrations beyond the `schema.rb` changes, let me know.

One thing that also isn't clear to me is why the mastodon input is shorter than the others... It's the same data type, but for some reason didn't get the `li.string` class that widens the other fields to 74%

<img width="1200" alt="Screenshot 2025-02-16 at 9 09 13 PM" src="https://github.com/user-attachments/assets/03ac2b69-a373-4c80-8cfa-975d2a40df67" />

<img width="1195" alt="Screenshot 2025-02-16 at 9 09 02 PM" src="https://github.com/user-attachments/assets/d187c255-ec7f-4d5f-8415-1c600d73e403" />

This is my first real rails change, so please give plenty of feedback on any conventions I'm not following or beginner mistakes I'm making!