### PR TITLE
add honeypot address field to new account sign up form

### DIFF
--- a/app/assets/stylesheets/participant.scss
+++ b/app/assets/stylesheets/participant.scss
@@ -2,10 +2,8 @@
   margin: 20px 10px;
 }
 
-.address {
-  opacity: 100%;
+.contact-details {
   position: absolute;
-  bottom: 0;
-  left: -10rem;
-  z-index: -1;
+  left: -9999px;
+  visibility: hidden;
 }

--- a/app/assets/stylesheets/participant.scss
+++ b/app/assets/stylesheets/participant.scss
@@ -1,3 +1,11 @@
 .row + .bio {
   margin: 20px 10px;
 }
+
+.address {
+  opacity: 100%;
+  position: absolute;
+  bottom: 0;
+  left: -10rem;
+  z-index: -1;
+}

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -56,7 +56,8 @@ class ParticipantsController < ApplicationController
     params.require(controller_name.singularize).permit(
       :name, :email, :password,
       :bio, :github_profile_username,
-      :twitter_handle, :code_of_conduct_agreement
+      :twitter_handle, :code_of_conduct_agreement,
+      :address
     )
   end
 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -57,7 +57,7 @@ class ParticipantsController < ApplicationController
       :name, :email, :password,
       :bio, :github_profile_username,
       :twitter_handle, :code_of_conduct_agreement,
-      :address
+      :contact_details
     )
   end
 

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -13,8 +13,8 @@ class Participant < ActiveRecord::Base
   attr_accessor :code_of_conduct_agreement
   
   # fake form field that acts as a honeypot for preventing spam. 
-  attr_accessor :address
-  validates_absence_of :address
+  attr_accessor :contact_details
+  validates_absence_of :contact_details
 
   acts_as_authentic do |config|
     config.crypto_provider = Authlogic::CryptoProviders::BCrypt

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -11,6 +11,10 @@ class Participant < ActiveRecord::Base
 
   # used for formtastic form to allow sending a field related to a separate model
   attr_accessor :code_of_conduct_agreement
+  
+  # fake form field that acts as a honeypot for preventing spam. 
+  attr_accessor :address
+  validates_absence_of :address
 
   acts_as_authentic do |config|
     config.crypto_provider = Authlogic::CryptoProviders::BCrypt

--- a/app/views/participants/new.html.erb
+++ b/app/views/participants/new.html.erb
@@ -8,6 +8,9 @@
     <%= f.input :name, :label => 'Your name', :hint => "Please use your real name. This will be used in our printed materials. Use JUST your name. For joint sessions, you will be able to add co-presenters." %>
     <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
     <%= f.input :password, :label => 'Password' %>
+    <div class="address">
+      <%= f.input :address, input_html: { tabindex: -1 } %>
+    </div>
     <%=
       f.input :code_of_conduct_agreement,
         as: :boolean,

--- a/app/views/participants/new.html.erb
+++ b/app/views/participants/new.html.erb
@@ -9,7 +9,7 @@
     <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
     <%= f.input :password, :label => 'Password' %>
     <div class="contact-details">
-      <%= f.input :contact_details, input_html: { autocomplete: "off", aria_hidden: "true", tabindex: -1 } %>
+      <%= f.input :contact_details, input_html: { autocomplete: "off", "aria-hidden": "true", tabindex: -1 } %>
     </div>
     <%=
       f.input :code_of_conduct_agreement,

--- a/app/views/participants/new.html.erb
+++ b/app/views/participants/new.html.erb
@@ -9,7 +9,7 @@
     <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
     <%= f.input :password, :label => 'Password' %>
     <div class="contact-details">
-      <%= f.input :contact_details, input_html: { autocomplete: "off", aria_hidden: "true" } %>
+      <%= f.input :contact_details, input_html: { autocomplete: "off", aria_hidden: "true", tabindex: -1 } %>
     </div>
     <%=
       f.input :code_of_conduct_agreement,

--- a/app/views/participants/new.html.erb
+++ b/app/views/participants/new.html.erb
@@ -8,8 +8,8 @@
     <%= f.input :name, :label => 'Your name', :hint => "Please use your real name. This will be used in our printed materials. Use JUST your name. For joint sessions, you will be able to add co-presenters." %>
     <%= f.input :email, :label => 'Your email', :hint => "Please use a real email address. We need this to contact you about your presentation." %>
     <%= f.input :password, :label => 'Password' %>
-    <div class="address">
-      <%= f.input :address, input_html: { tabindex: -1 } %>
+    <div class="contact-details">
+      <%= f.input :contact_details, input_html: { autocomplete: "off", aria_hidden: "true" } %>
     </div>
     <%=
       f.input :code_of_conduct_agreement,

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -32,6 +32,19 @@ describe ParticipantsController do
       expect(response).to redirect_to root_path
       expect(flash[:notice]).to eq "Thanks for registering an account. You may now create sessions and mark sessions you'd like to attend."
     end
+
+    it "should not be successful if a bot provides contact_details field" do
+      expect{
+        post :create, params: { participant: { name: 'spam bot', 
+                                               email: 'spambot@example.org', 
+                                               password: 'spam-bot',
+                                               contact_details: 'this is a honeypot field that i fell for because im a spam bot'
+                              }
+        }
+      }.not_to change(Participant, :count)
+      expect(response).to render_template(:new)
+      expect(flash[:error]).to eq "There was a problem creating that account."
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
addresses issue #262 

## summary of changes
* creates a fake form field only visible to bots. the form field is called `contact_details` in order to appear realistic. it is positioned off screen, is completely opaque, and is removed from the tabindex. 
* enforces absence of `contact_details` field at the controller level. if a user tries to submit the form with `contact_details` present, the account cannot be created.


## how to test
there is an rspec that tests that accounts cannot be created when this field is provided. 

to test manually: 
* ensure that the `contact_details` field is not announced by a screen reader
* ensure that a user cannot see or navigate to the `contact_details` field
* ensure that a user can sign up normally
* confirm that there are no visual changes to the form on this branch.

to manually test the `contact_details` field, remove the css for `.contact-details` in `participant.scss` and fill out the field when submitting the form. 