### PR TITLE
Update wording, content and styles for clarity

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -5,7 +5,7 @@ class Notifier < ActionMailer::Base
   def password_reset_instructions(participant)
     @participant = participant
     @sent_on = Time.now
-    mail(to: @participant.email, subject: "Password Reset Instructions")
+    mail(to: @participant.email, subject: "Password Reset Instructions for Minnebar")
   end
 
   def participant_email_confirmation(participant)

--- a/app/views/notifier/participant_email_confirmation.html.erb
+++ b/app/views/notifier/participant_email_confirmation.html.erb
@@ -3,3 +3,11 @@
 <p><%= link_to "Confirm my email", confirm_email_participant_url(@participant, token: @participant.perishable_token) %></p>
 
 <p>Once confirmed, you'll be redirected to the Sessionizer and ready to submit or vote for Minnebar sessions!</p>
+
+<p>
+  If you need further assistance, please contact us at <a href="mailto:support@minnestar.org">support@minnestar.org</a>.
+<p>
+
+<p>
+  - The Minnestar Team
+</p>

--- a/app/views/notifier/password_reset_instructions.html.erb
+++ b/app/views/notifier/password_reset_instructions.html.erb
@@ -1,9 +1,18 @@
-<h1>Password Reset Instructions</h1>
-
 <p>
-  A request to reset your password has been made. If you did not make
-  this request, simply ignore this email. If you did make this
-  request, please follow the link below.
+  We received a request to reset your Sessionizer password.
+  If you did not request this, you can safely ignore this email.
 </p>
 
-<%= link_to "Reset Password!", edit_password_reset_url(@participant.perishable_token) %>
+<p>
+  To reset your password, please click the link below:
+</p>
+
+<%= link_to "Reset my password", edit_password_reset_url(@participant.perishable_token) %>
+
+<p>
+  If you need further assistance, please contact us at <a href="mailto:support@minnestar.org">support@minnestar.org</a>.
+<p>
+
+<p>
+  - The Minnestar Team
+</p>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% if Settings.allow_new_sessions? %>
   <% if current_participant.email_confirmed? %>
     <% title('New Session') %>
-    <p><strong>Note: sessions can be at most 45 minutes long.</strong></p>
+    <p><strong>Note: sessions can be at most 40 minutes long.</strong></p>
     <%= render 'form' %>
   <% else %>
     <% title('Email Confirmation Required') %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,10 +1,12 @@
+<hr>
 <footer>
-
   <div class="row">
-    <p>Find a bug? Please submit an <a href="https://github.com/minnestar/sessionizer/issues">issue</a>. Want to contribute? Check out the <a href="https://github.com/minnestar/sessionizer">code</a>.</p>
+    <p><a href="https://minnestar.org">Minnestar</a> is dedicated to providing a welcoming, inclusive, and harassment-free experience for everyone. Please read our  <a href="https://minnestar.org/code-of-conduct">Code of Conduct</a>.</p>
   </div>
   <div class="row">
-    <p><a href="https://minnestar.org">Minnestar</a> is dedicated to providing a harassment-free experience for everyone. Read our Code of Conduct <a href="https://minnestar.org/code-of-conduct">here</a>.</p>
+    <p><strong>Need Help?</strong> For questions, accessibility needs, or support, contact <a href="mailto:support@minnestar.org">support@minnestar.org</a>. We're here to ensure everyone has a great experience!</p>
   </div>
-
+  <div class="row">
+    <p><strong>Find a bug?</strong> Please submit an <a href="https://github.com/minnestar/sessionizer/issues">issue</a>. Want to contribute? Check out the <a href="https://github.com/minnestar/sessionizer">code</a>.</p>
+  </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
-<hr>
 <footer>
+  <hr />
   <div class="row">
     <p><a href="https://minnestar.org">Minnestar</a> is dedicated to providing a welcoming, inclusive, and harassment-free experience for everyone. Please read our  <a href="https://minnestar.org/code-of-conduct">Code of Conduct</a>.</p>
   </div>


### PR DESCRIPTION
Small tweaks to wording, content, and styling that Meg noticed

* Password resets
    - Update subject line
    - Update body content
* Email confirmations
    - Add team sign off
* Footer
    - Update styles, add horizontal line
    - Add contact us section
    - Reorder content
* Add session page
    - Update max session length `45` => `40` min