### PR TITLE
do not show email confirmation flash when logged out; ensure confirma…

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -18,8 +18,8 @@ class ParticipantsController < ApplicationController
   end
 
   def show
-    unless @participant.email_confirmed?
-      flash[:alert] = email_confirmation_alert(@participant)
+    if logged_in? && !current_participant.email_confirmed?
+      flash[:alert] = email_confirmation_alert(current_participant)
     end
     respond_with(@participant)
   end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -53,6 +53,44 @@ describe ParticipantsController do
       expect(response).to be_successful
       expect(assigns(:participant)).to be_kind_of Participant
     end
+
+    context "when logged in" do
+      context "when logged in user has not confirmed email" do
+        let(:unconfirmed_email_participant) { create(:participant, email_confirmed_at: nil )}
+
+        before do
+          activate_authlogic
+          ParticipantSession.create(unconfirmed_email_participant)
+        end
+
+        it "should display confirm email flash message" do
+          get :show, params: {id: participant}
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+
+    context "when logged in user has confirmed email" do
+      let(:unconfirmed_email_participant) { create(:participant, email_confirmed_at: Time.now )}
+        
+      before do
+        activate_authlogic
+        ParticipantSession.create(unconfirmed_email_participant)
+      end
+
+      it "should not display confirm email flash message" do
+        get :show, params: {id: participant}
+        expect(flash[:alert]).not_to be_present
+      end
+    end
+
+
+    context "when not logged in" do
+      it "should not show confirm email flash message" do
+        get :show, params: {id: participant}
+        expect(flash[:alert]).not_to be_present
+      end
+    end
   end
 
   context "when the logged in user operates on someone elses record" do


### PR DESCRIPTION
…tion email sent to logged in user

## summary of changes
* checks if a user is logged in before showing the "confirm email" flash alert on the participant `/show` view
* ensures that confirmation email is sent to the logged-in user on this view, not the participant being viewed