### PR TITLE
Use dynamic meta description content from current event

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,8 +28,13 @@ module ApplicationHelper
     Nokogiri::HTML::DocumentFragment.parse(html.scrub).to_html
   end
 
+  # TODO: Add venue field to Event model and use it here instead of hardcoding "Best Buy HQ"
+  def default_meta_description
+    "#{Event.current_event.name} | #{Event.current_event.date.strftime("%B %e, %Y")} | Best Buy HQ"
+  end
+
   def meta_description
-    content_for?(:meta_description) ? content_for(:meta_description) : 'Minnebar'
+    content_for?(:meta_description) ? content_for(:meta_description) : default_meta_description
   end
 
   def sanitize_html(html)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,9 +28,13 @@ module ApplicationHelper
     Nokogiri::HTML::DocumentFragment.parse(html.scrub).to_html
   end
 
-  # TODO: Add venue field to Event model and use it here instead of hardcoding "Best Buy HQ"
   def default_meta_description
-    "#{Event.current_event.name} | #{Event.current_event.date.strftime("%B %e, %Y")} | Best Buy HQ"
+    if Event.current_event
+      # TODO: Add venue field to Event model and use it here instead of hardcoding "Best Buy HQ"
+      "#{Event.current_event.name} | #{Event.current_event.date.strftime("%B %e, %Y")} | Best Buy HQ"
+    else
+      "Minnebar"
+    end
   end
 
   def meta_description

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="<%= image_url 'twitter-card.png' %>">
     <meta property="og:image" content="<%= image_url 'twitter-card.png' %>">
-    <meta property="og:image:alt" content="Minnebar 19 | May 3, 2025 | Best Buy HQ">
+    <meta property="og:image:alt" content="<%= default_meta_description %>">
     <% if meta_description %>
     <meta property="og:description" content="<%= meta_description %>" />
     <meta name="twitter:description" content="<%= meta_description %>">


### PR DESCRIPTION
Use dynamic content from `Event.current_event` instead of static values for the meta tag description.