### PR TITLE
Add counter caches to prevent admin panel n+1 queries

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -11,20 +11,20 @@ ActiveAdmin.register_page "Dashboard" do
           attributes_table_for Event.includes(:sessions, :rooms, :timeslots).current_event do
             row :name
             row :date
-            row "Show Schedule" do
-              settings.show_schedule
-            end
             row "Allow New Sessions" do
               settings.allow_new_sessions
             end
+            row "Show Schedule" do
+              settings.show_schedule
+            end
             row "# of Sessions" do |event|
-              event.sessions.size
+              event.sessions_count
             end
             row "# of Rooms" do |event|
-              event.rooms.size
+              event.rooms_count
             end
             row "# of Timeslots" do |event|
-              event.timeslots.size
+              event.timeslots_count
             end
           end
         end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -67,9 +67,7 @@ ActiveAdmin.register_page "Dashboard" do
         column :presenters, sortable: false do |session|
           session.presenters.map { |presenter| link_to presenter.name, admin_participant_path(presenter) }.join(", ").html_safe
         end
-        column("Votes", :attendances_count, sortable: :attendances_count) do |session|
-          session.attendances_count
-        end
+        column("Votes", sortable: :attendances_count, &:attendances_count)
         column :timeslot, sortable: :timeslot_id do |session|
           session.timeslot&.to_s
         end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -32,21 +32,52 @@ ActiveAdmin.register_page "Dashboard" do
     end
 
     panel "Current Event Sessions" do
-      table_for Event.includes(:sessions).current_event.sessions.includes(:presenters, :attendances, :timeslot, :room).order(:timeslot_id) do
-        column :title do |session|
-          link_to session.title, admin_session_path(session)
+      # Define allowed sort columns and their database equivalents
+      sortable_columns = {
+        'title' => 'sessions.title',
+        'attendances_count' => 'sessions.attendances_count',
+        'timeslot_id' => 'sessions.timeslot_id',
+        'room' => 'rooms.name',
+        'created_at' => 'sessions.created_at'
+      }
+
+      # Get sort column and direction from params, with validation
+      raw_sort = params[:order]&.gsub(/_desc|_asc/, '')  # Remove direction suffix
+
+      # If sort param exists, use it; otherwise use default sort (timeslot, then votes)
+      order_clause = if params[:order].present?
+        sort_column = sortable_columns[raw_sort] || 'sessions.timeslot_id'
+        sort_direction = params[:order]&.end_with?('desc') ? 'desc' : 'asc'
+        Arel.sql("#{sort_column} #{sort_direction}")
+      else
+        Arel.sql('sessions.timeslot_id, sessions.attendances_count DESC')
+      end
+
+      sessions = Event.includes(:sessions)
+                     .current_event
+                     .sessions
+                     .includes(:presenters, :attendances, :timeslot, :room)
+                     .joins('LEFT JOIN rooms ON rooms.id = sessions.room_id')
+                     .order(order_clause)
+
+      table_for sessions, sortable: true do
+        column :title, sortable: :title do |session|
+          link_to truncate(session.title, length: 80), admin_session_path(session)
         end
-        column :presenters do |session|
+        column :presenters, sortable: false do |session|
           session.presenters.map { |presenter| link_to presenter.name, admin_participant_path(presenter) }.join(", ").html_safe
         end
-        column("Votes") do |session|
-          session.attendances.size
+        column("Votes", :attendances_count, sortable: :attendances_count) do |session|
+          session.attendances_count
         end
-        column :timeslot do |session|
+        column :timeslot, sortable: :timeslot_id do |session|
           session.timeslot&.to_s
         end
-        column :room do |session|
+        column :room, sortable: :room do |session|
           session.room&.name
+        end
+        column("Created", sortable: :created_at) do |session|
+          session.created_at.strftime("%-m/%-d/%y")
         end
       end
     end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -91,9 +91,7 @@ ActiveAdmin.register Event do
         column :presenters, sortable: false do |session|
           session.presenters.map { |presenter| link_to presenter.name, admin_participant_path(presenter) }.join(", ").html_safe
         end
-        column("Votes", :attendances_count, sortable: :attendances_count) do |session|
-          session.attendances_count
-        end
+        column("Votes", sortable: :attendances_count, &:attendances_count)
         column :timeslot, sortable: :timeslot_id do |session|
           session.timeslot&.to_s
         end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -50,14 +50,14 @@ ActiveAdmin.register Event do
       row "# of Rooms" do |event|
         event.rooms_count
       end
-      row "# of Sessions" do |event|
-        event.sessions_count
+      row("# of Sessions") do |event|
+        link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
       end
       row :created_at
       row :updated_at
     end
 
-    panel "Sessions" do
+    panel "Sessions (#{event.sessions_count})" do
       # Define allowed sort columns and their database equivalents
       sortable_columns = {
         'title' => 'sessions.title',

--- a/app/admin/participants.rb
+++ b/app/admin/participants.rb
@@ -46,7 +46,7 @@ ActiveAdmin.register Participant do
     end
 
     panel "Presentations (#{participant.presentations_count})" do
-      table_for participant.presentations.order(created_at: :desc) do
+      table_for participant.presentations.includes(session: :event).order(created_at: :desc) do
         column(:title) do |p|
           (link_to(p.session.title, admin_session_path(p.session)) +
            (p.session.canceled? ? " (CANCELED)" : "")).html_safe

--- a/app/admin/participants.rb
+++ b/app/admin/participants.rb
@@ -23,8 +23,8 @@ ActiveAdmin.register Participant do
       truncate(participant.bio, length: 80)
     end
     column(:confirmed, &:email_confirmed?)
-    column(:sessions) { |p| p.presentations.size }
-    column(:votes) { |p| p.attendances.size }
+    column("Sessions", sortable: :presentations_count, &:presentations_count)
+    column("Votes", sortable: :attendances_count, &:attendances_count)
     column(:created, sortable: :created_at) { |p| p.created_at.strftime("%-m/%-d/%y") }
     actions
   end
@@ -36,8 +36,8 @@ ActiveAdmin.register Participant do
       row :bio do |participant|
         markdown participant.bio
       end
-      row(:presentation_count) { |p| p.presentations.size }
-      row(:attendance_count) { |p| p.attendances.size }
+      row("Presentations", &:presentations_count)
+      row("Attendances", &:attendances_count)
       row("Email confirmed") do |p|
         status_tag p.email_confirmed? ? "Yes" : "No", class: p.email_confirmed? ? :ok : :error
       end
@@ -45,7 +45,7 @@ ActiveAdmin.register Participant do
       row :created_at
     end
 
-    panel "Presentations" do
+    panel "Presentations (#{participant.presentations_count})" do
       table_for participant.presentations.order(created_at: :desc) do
         column(:title) do |p|
           (link_to(p.session.title, admin_session_path(p.session)) +
@@ -57,7 +57,7 @@ ActiveAdmin.register Participant do
       end
     end
 
-    panel "Interested Sessions (attendances)" do
+    panel "Interested Sessions (#{participant.attendances_count})" do
       table_for participant.attendances.includes(session: :event).order('events.date desc, sessions.title') do
         column(:title) do |attendance|
           (link_to(attendance.session.title, admin_session_path(attendance.session)) +

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -42,7 +42,7 @@ ActiveAdmin.register Session do
         link_to presenter.name, admin_participant_path(presenter)
       end.join(", ").html_safe
     end
-    column("Event", sortable: :event) do |session|
+    column("Event", sortable: 'events.name') do |session|
       (link_to(session.event.name, admin_event_path(session.event)) + " (#{session.event.date.year})").html_safe if session.event
     end
     column("Votes", :attendances_count, sortable: :attendances_count) do |session|

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -77,7 +77,7 @@ ActiveAdmin.register Session do
       row :updated_at
     end
 
-    panel "Interested Participants" do
+    panel "Interested Participants (#{session.attendances_count})" do
       table_for session.attendances.includes(:participant).order('created_at desc') do
         column :name do |attendance|
           link_to attendance.participant.name, admin_participant_path(attendance.participant)

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -42,14 +42,17 @@ ActiveAdmin.register Session do
         link_to presenter.name, admin_participant_path(presenter)
       end.join(", ").html_safe
     end
-    column("Event") do |session|
+    column("Event", sortable: :event) do |session|
       (link_to(session.event.name, admin_event_path(session.event)) + " (#{session.event.date.year})").html_safe if session.event
     end
-    column("Votes") do |session|
-      session.attendances.size
+    column("Votes", :attendances_count, sortable: :attendances_count) do |session|
+      session.attendances_count
     end
-    column :timeslot
-    column :room
+    column :timeslot, sortable: :timeslot
+    column :room, sortable: :room
+    column("Created", sortable: :created_at) do |session|
+      session.created_at.strftime("%-m/%-d/%y")
+    end
   end
 
   show  title: :title do
@@ -64,7 +67,7 @@ ActiveAdmin.register Session do
       row :level
       row :categories
       row("Votes") do |session|
-        session.attendances.size
+        session.attendances_count
       end
       row :timeslot
       row :room

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -55,9 +55,7 @@ ActiveAdmin.register Session do
     column("Event", sortable: 'events.date') do |session|
       (link_to(session.event.name, admin_event_path(session.event)) + " (#{session.event.date.year})").html_safe if session.event
     end
-    column("Votes", :attendances_count, sortable: :attendances_count) do |session|
-      session.attendances_count
-    end
+    column("Votes", sortable: :attendances_count, &:attendances_count)
     column :timeslot, sortable: :timeslot
     column :room, sortable: :room
     column("Created", sortable: :created_at) do |session|

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -1,6 +1,16 @@
 ActiveAdmin.register Session do
   menu priority: 2
 
+  scope :active, default: true do |sessions|
+    sessions.where('sessions.event_id >= 0')
+  end
+
+  scope :canceled do |sessions|
+    sessions.where('sessions.event_id < 0')
+  end
+
+  scope :all
+
   permit_params(
     :participant_id,
     :title,
@@ -42,7 +52,7 @@ ActiveAdmin.register Session do
         link_to presenter.name, admin_participant_path(presenter)
       end.join(", ").html_safe
     end
-    column("Event", sortable: 'events.name') do |session|
+    column("Event", sortable: 'events.date') do |session|
       (link_to(session.event.name, admin_event_path(session.event)) + " (#{session.event.date.year})").html_safe if session.event
     end
     column("Votes", :attendances_count, sortable: :attendances_count) do |session|

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,5 +1,5 @@
 class Attendance < ActiveRecord::Base
-  belongs_to :session
+  belongs_to :session, counter_cache: true
   belongs_to :participant
 
   attr_accessor :name, :email, :password

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,6 +1,6 @@
 class Attendance < ActiveRecord::Base
   belongs_to :session, counter_cache: true
-  belongs_to :participant
+  belongs_to :participant, counter_cache: true
 
   attr_accessor :name, :email, :password
 

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -3,7 +3,7 @@
 
 class Presentation < ActiveRecord::Base
   belongs_to :session
-  belongs_to :participant
+  belongs_to :participant, counter_cache: true
 
   validates_presence_of :session_id
   validates_presence_of :participant_id

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,5 +1,5 @@
 class Room < ActiveRecord::Base
-  belongs_to :event
+  belongs_to :event, counter_cache: true
   has_many :sessions, :dependent => :nullify
 
   # TODO: Deprecate the default scope.

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -6,7 +6,7 @@ class Session < ActiveRecord::Base
 
   has_many :presentations, :dependent => :destroy
   has_many :presenters, :through => :presentations, :source => :participant
-  belongs_to :event
+  belongs_to :event, counter_cache: true
   belongs_to :timeslot
   belongs_to :room
   belongs_to :level

--- a/app/models/timeslot.rb
+++ b/app/models/timeslot.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 class Timeslot < ActiveRecord::Base
-  belongs_to :event
+  belongs_to :event, counter_cache: true
   has_many :sessions, dependent: :nullify
   has_many :presenter_timeslot_restrictions, dependent: :destroy
 

--- a/db/migrate/20250330143647_add_counter_caches_to_events.rb
+++ b/db/migrate/20250330143647_add_counter_caches_to_events.rb
@@ -3,5 +3,13 @@ class AddCounterCachesToEvents < ActiveRecord::Migration[7.1]
     add_column :events, :sessions_count, :integer, default: 0
     add_column :events, :rooms_count, :integer, default: 0
     add_column :events, :timeslots_count, :integer, default: 0
+
+    reversible do |dir|
+      dir.up do
+        say_with_time "Updating counter caches..." do
+          Event.find_each { |event| Event.reset_counters(event.id, :sessions, :rooms, :timeslots) }
+        end
+      end
+    end
   end
 end

--- a/db/migrate/20250330143647_add_counter_caches_to_events.rb
+++ b/db/migrate/20250330143647_add_counter_caches_to_events.rb
@@ -1,0 +1,7 @@
+class AddCounterCachesToEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :events, :sessions_count, :integer, default: 0
+    add_column :events, :rooms_count, :integer, default: 0
+    add_column :events, :timeslots_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20250330143647_add_counter_caches_to_events.rb
+++ b/db/migrate/20250330143647_add_counter_caches_to_events.rb
@@ -6,7 +6,7 @@ class AddCounterCachesToEvents < ActiveRecord::Migration[7.1]
 
     reversible do |dir|
       dir.up do
-        say_with_time "Updating counter caches..." do
+        say_with_time "Updating Event counter caches..." do
           Event.find_each { |event| Event.reset_counters(event.id, :sessions, :rooms, :timeslots) }
         end
       end

--- a/db/migrate/20250330164250_add_counter_caches_to_sessions.rb
+++ b/db/migrate/20250330164250_add_counter_caches_to_sessions.rb
@@ -1,0 +1,13 @@
+class AddCounterCachesToSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :sessions, :attendances_count, :integer, default: 0
+
+    reversible do |dir|
+      dir.up do
+        say_with_time "Updating attendance counter caches..." do
+          Session.find_each { |session| Session.reset_counters(session.id, :attendances) }
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250330164250_add_counter_caches_to_sessions.rb
+++ b/db/migrate/20250330164250_add_counter_caches_to_sessions.rb
@@ -4,7 +4,7 @@ class AddCounterCachesToSessions < ActiveRecord::Migration[7.1]
 
     reversible do |dir|
       dir.up do
-        say_with_time "Updating attendance counter caches..." do
+        say_with_time "Updating Session counter caches..." do
           Session.find_each { |session| Session.reset_counters(session.id, :attendances) }
         end
       end

--- a/db/migrate/20250330172156_add_counter_caches_to_participants.rb
+++ b/db/migrate/20250330172156_add_counter_caches_to_participants.rb
@@ -1,0 +1,27 @@
+class AddCounterCachesToParticipants < ActiveRecord::Migration[7.1]
+  def change
+    add_column :participants, :presentations_count, :integer, default: 0
+    add_column :participants, :attendances_count, :integer, default: 0
+    
+    # using raw SQL to update counter caches here to make this more performant
+    reversible do |dir|
+      dir.up do
+        say_with_time "Updating participant counter caches..." do
+          execute <<-SQL
+            UPDATE participants 
+            SET presentations_count = (
+              SELECT COUNT(*)
+              FROM presentations
+              WHERE presentations.participant_id = participants.id
+            ),
+            attendances_count = (
+              SELECT COUNT(*)
+              FROM attendances
+              WHERE attendances.participant_id = participants.id
+            )
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250330172156_add_counter_caches_to_participants.rb
+++ b/db/migrate/20250330172156_add_counter_caches_to_participants.rb
@@ -6,7 +6,7 @@ class AddCounterCachesToParticipants < ActiveRecord::Migration[7.1]
     # using raw SQL to update counter caches here to make this more performant
     reversible do |dir|
       dir.up do
-        say_with_time "Updating participant counter caches..." do
+        say_with_time "Updating Participant counter caches..." do
           execute <<-SQL
             UPDATE participants 
             SET presentations_count = (

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_30_143647) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_30_164250) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_30_143647) do
     t.integer "level_id"
     t.boolean "manually_scheduled", default: false, null: false
     t.integer "manual_attendance_estimate"
+    t.integer "attendances_count", default: 0
     t.index ["level_id"], name: "index_sessions_on_level_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_30_164250) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_30_172156) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -92,6 +92,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_30_164250) do
     t.string "persistence_token", limit: 255
     t.string "perishable_token", limit: 255, default: "", null: false
     t.datetime "email_confirmed_at", precision: nil
+    t.integer "presentations_count", default: 0
+    t.integer "attendances_count", default: 0
     t.index ["email"], name: "index_participants_on_email", unique: true
     t.index ["perishable_token"], name: "index_participants_on_perishable_token"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_13_020004) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_30_143647) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -64,6 +64,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_13_020004) do
     t.date "date", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "sessions_count", default: 0
+    t.integer "rooms_count", default: 0
+    t.integer "timeslots_count", default: 0
   end
 
   create_table "levels", id: :serial, force: :cascade do |t|

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -15,9 +15,6 @@ FactoryBot.define do
       after(:create) do |event, evaluator|
         create_list(:room, evaluator.rooms_count, event: event)
         create_list(:timeslot, evaluator.timeslots_count, event: event)
-
-        # Reset counter caches after creating associations
-        Event.reset_counters(event.id, :rooms, :timeslots)
       end
     end
   end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -15,6 +15,9 @@ FactoryBot.define do
       after(:create) do |event, evaluator|
         create_list(:room, evaluator.rooms_count, event: event)
         create_list(:timeslot, evaluator.timeslots_count, event: event)
+
+        # Reset counter caches after creating associations
+        Event.reset_counters(event.id, :rooms, :timeslots)
       end
     end
   end

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -1,12 +1,15 @@
-
 FactoryBot.define do
   factory :session do
     sequence :title do |n|
-      " Session #{n}"
+      "Session #{n}"
     end
     description { 'whatever' }
     participant
     association :event
-    association :room
+
+    # ensure room is associated with the same event as the session
+    after(:build) do |session|
+      session.room = session.event.rooms.first || create(:room, event: session.event)
+    end
   end
 end


### PR DESCRIPTION
The new admin panel is in place, at a barebones level, and with that includes a few n+1 queries (on the events and dashboards pages). This PR fixes that by introducing counter caches and using them to make those columns sortable where applicable.

----

* [x] Add counter caches for `Event` associations: `session_count`, `room_count`, and `timeslot_count`
* [x] Add counter cache for `Session` associations: `attendance_count`
* [x] Add counter caches for `Participant` associations: `session_count`, `presentations_count`, and `attendances_count`

Note that the following commands to reset counter cache _have been included_ in the migrations to add `*_count` columns to each of the models. I figure that's the best/easiest way to ensure they get run post migration, without having to do it manually.

```
# events
Event.find_each { |event| Event.reset_counters(event.id, :sessions, :rooms, :timeslots) }

# sessions
Session.find_each { |session| Session.reset_counters(session.id, :attendances) }

# participants -- this one needed to be done with raw SQL because it was 10x faster than using active record

execute <<-SQL
  UPDATE participants 
  SET presentations_count = (
    SELECT COUNT(*)
    FROM presentations
    WHERE presentations.participant_id = participants.id
  ),
  attendances_count = (
    SELECT COUNT(*)
    FROM attendances
    WHERE attendances.participant_id = participants.id
  )
SQL

```