### PR TITLE
Add settings, timeslots, and rooms to admin panel

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register_page "Dashboard" do
               link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
             end
             row "# of Rooms" do |event|
-              event.rooms_count
+              link_to event.rooms_count, admin_event_rooms_path(event)
             end
             row "# of Timeslots" do |event|
               link_to event.timeslots_count, admin_event_timeslots_path(event)
@@ -72,10 +72,10 @@ ActiveAdmin.register_page "Dashboard" do
         end
         column("Votes", sortable: :attendances_count, &:attendances_count)
         column :timeslot, sortable: :timeslot_id do |session|
-          session.timeslot&.to_s
+          link_to session.timeslot&.to_s, admin_event_timeslot_path(session.event, session.timeslot) if session.timeslot
         end
         column :room, sortable: :room do |session|
-          session.room&.name
+          link_to session.room&.name, admin_event_room_path(session.event, session.room) if session.room
         end
         column("Created", sortable: :created_at) do |session|
           session.created_at.strftime("%-m/%-d/%y")

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -11,20 +11,23 @@ ActiveAdmin.register_page "Dashboard" do
           attributes_table_for Event.includes(:sessions, :rooms, :timeslots).current_event do
             row :name
             row :date
-            row "Allow New Sessions" do
-              settings.allow_new_sessions
-            end
-            row "Show Schedule" do
-              settings.show_schedule
-            end
             row "# of Sessions" do |event|
-              event.sessions_count
+              link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
             end
             row "# of Rooms" do |event|
               event.rooms_count
             end
             row "# of Timeslots" do |event|
               event.timeslots_count
+            end
+            row "Allow New Sessions" do
+              settings.allow_new_sessions
+            end
+            row "Show Schedule" do
+              settings.show_schedule
+            end
+            row "Edit Settings" do
+              link_to "Edit Settings", edit_admin_setting_path(1)
             end
           end
         end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register_page "Dashboard" do
               event.rooms_count
             end
             row "# of Timeslots" do |event|
-              event.timeslots_count
+              link_to event.timeslots_count, admin_event_timeslots_path(event)
             end
             row "Allow New Sessions" do
               settings.allow_new_sessions
@@ -26,7 +26,7 @@ ActiveAdmin.register_page "Dashboard" do
             row "Show Schedule" do
               settings.show_schedule
             end
-            row "Edit Settings" do
+            row "Settings" do
               link_to "Edit Settings", edit_admin_setting_path(1)
             end
           end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -46,15 +46,29 @@ ActiveAdmin.register Event do
     attributes_table do
       row :name
       row :date
-      row :timeslots
+      row "# of Sessions" do |event|
+        link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
+      end
       row "# of Rooms" do |event|
         event.rooms_count
       end
-      row("# of Sessions") do |event|
-        link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
+      row "# of Timeslots" do |event|
+        event.timeslots_count
       end
+      row :timeslots
       row :created_at
       row :updated_at
+      if event.current?
+        row "Allow New Sessions" do
+          Settings.first.allow_new_sessions
+        end
+        row "Show Schedule" do
+          Settings.first.show_schedule
+        end
+        row "Edit Settings" do
+          link_to "Edit Settings", edit_admin_setting_path(1)
+        end
+      end
     end
 
     panel "Sessions (#{event.sessions_count})" do

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -111,10 +111,10 @@ ActiveAdmin.register Event do
         end
         column("Votes", sortable: :attendances_count, &:attendances_count)
         column :timeslot, sortable: :timeslot_id do |session|
-          session.timeslot&.to_s
+          link_to session.timeslot&.to_s, admin_event_timeslot_path(session.event, session.timeslot) if session.timeslot
         end
         column :room, sortable: :room do |session|
-          session.room&.name
+          link_to session.room&.name, admin_event_room_path(session.event, session.room) if session.room
         end
         column("Created", sortable: :created_at) do |session|
           session.created_at.strftime("%-m/%-d/%y")

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register Event do
       event.rooms_count
     end
     column("# of Timeslots") do |event|
-      event.timeslots_count
+      link_to event.timeslots_count, admin_event_timeslots_path(event)
     end
   end
 
@@ -53,9 +53,13 @@ ActiveAdmin.register Event do
         event.rooms_count
       end
       row "# of Timeslots" do |event|
-        event.timeslots_count
+        link_to event.timeslots_count, admin_event_timeslots_path(event)
       end
-      row :timeslots
+      row "Timeslots" do |event|
+        event.timeslots.map do |timeslot|
+          link_to timeslot.to_s, admin_event_timeslot_path(event, timeslot)
+        end.join('<br>').html_safe
+      end
       row :created_at
       row :updated_at
       if event.current?
@@ -65,7 +69,7 @@ ActiveAdmin.register Event do
         row "Show Schedule" do
           Settings.first.show_schedule
         end
-        row "Edit Settings" do
+        row "Settings" do
           link_to "Edit Settings", edit_admin_setting_path(1)
         end
       end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -35,7 +35,7 @@ ActiveAdmin.register Event do
       link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
     end
     column("# of Rooms") do |event|
-      event.rooms_count
+      link_to event.rooms_count, admin_event_rooms_path(event)
     end
     column("# of Timeslots") do |event|
       link_to event.timeslots_count, admin_event_timeslots_path(event)
@@ -50,7 +50,7 @@ ActiveAdmin.register Event do
         link_to event.sessions_count, admin_sessions_path(q: { event_id_eq: event.id })
       end
       row "# of Rooms" do |event|
-        event.rooms_count
+        link_to event.rooms_count, admin_event_rooms_path(event)
       end
       row "# of Timeslots" do |event|
         link_to event.timeslots_count, admin_event_timeslots_path(event)

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register Event do
   menu priority: 1
   permit_params :name, :date
 
-  # Only eager load associations on the show page
+  # eager load associations on the show page
   controller do
     def scoped_collection
       collection = super

--- a/app/admin/rooms.rb
+++ b/app/admin/rooms.rb
@@ -6,9 +6,10 @@ ActiveAdmin.register Room do
   permit_params :event_id, :name, :capacity, :schedulable
   config.sort_order = 'capacity_desc'
 
+  # don't allow delete
   actions :all, except: [:destroy]
 
-  # eager load associations on show page
+  # eager load associations on the show page
   controller do
     def scoped_collection
       collection = super

--- a/app/admin/rooms.rb
+++ b/app/admin/rooms.rb
@@ -41,15 +41,21 @@ ActiveAdmin.register Room do
     end
 
     panel "Sessions" do
-      table_for room.sessions.order('sessions.timeslot_id') do
-        column("Timeslot") do |session|
-          link_to session.timeslot.to_s, admin_event_timeslot_path(session.event, session.timeslot)
+      if room.sessions.any?
+        table_for room.sessions.order('sessions.timeslot_id') do
+          column("Timeslot") do |session|
+            link_to session.timeslot.to_s, admin_event_timeslot_path(session.event, session.timeslot)
         end
         column :title do |session|
           link_to session.title, admin_session_path(session)
         end
         column :presenters
-        column("Votes", &:attendances_count)
+          column("Votes", &:attendances_count)
+        end
+      else
+        div do
+          "No sessions scheduled in this room."
+        end
       end
     end
   end

--- a/app/admin/rooms.rb
+++ b/app/admin/rooms.rb
@@ -49,6 +49,7 @@ ActiveAdmin.register Room do
           link_to session.title, admin_session_path(session)
         end
         column :presenters
+        column("Votes", &:attendances_count)
       end
     end
   end

--- a/app/admin/rooms.rb
+++ b/app/admin/rooms.rb
@@ -1,0 +1,55 @@
+ActiveAdmin.register Room do
+  config.filters = false
+
+  belongs_to :event
+
+  permit_params :event_id, :name, :capacity, :schedulable
+  config.sort_order = 'capacity_desc'
+
+  actions :all, except: [:destroy]
+
+  # eager load associations on show page
+  controller do
+    def scoped_collection
+      collection = super
+      if action_name == "show"
+        collection.includes(sessions: [:timeslot, { presentations: :participant }])
+      else
+        collection
+      end
+    end
+  end
+
+  index do
+    column :id
+    column :event
+    column :name do |room|
+      link_to room.name, admin_event_room_path(room.event, room)
+    end
+    column :capacity
+    column :schedulable
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :event
+      row :name
+      row :capacity
+      row :schedulable
+    end
+
+    panel "Sessions" do
+      table_for room.sessions.order('sessions.timeslot_id') do
+        column("Timeslot") do |session|
+          link_to session.timeslot.to_s, admin_event_timeslot_path(session.event, session.timeslot)
+        end
+        column :title do |session|
+          link_to session.title, admin_session_path(session)
+        end
+        column :presenters
+      end
+    end
+  end
+end

--- a/app/admin/settings.rb
+++ b/app/admin/settings.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Settings do
-  menu false
+  menu priority: 10, parent: "Admin", label: "Event Settings"
   config.filters = false
   actions :index, :edit, :update, :show
 

--- a/app/admin/settings.rb
+++ b/app/admin/settings.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Settings do
+  menu false
+  config.filters = false
+  actions :index, :edit, :update, :show
+
+  controller do
+    def find_resource
+      Settings.first
+    end
+  end
+
+  permit_params :allow_new_sessions, :show_schedule
+
+  index do
+    column :id
+    column :allow_new_sessions
+    column :show_schedule
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :allow_new_sessions
+      row :show_schedule
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :allow_new_sessions
+      f.input :show_schedule
+    end
+    f.actions
+  end
+end

--- a/app/admin/settings.rb
+++ b/app/admin/settings.rb
@@ -5,6 +5,7 @@ ActiveAdmin.register Settings do
   config.filters = false
   actions :index, :edit, :update, :show
 
+  # assume there is only one settings object
   controller do
     def find_resource
       Settings.first

--- a/app/admin/timeslots.rb
+++ b/app/admin/timeslots.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register Timeslot do
-  menu parent: "Events", label: "Timeslots"
   config.filters = false
 
   belongs_to :event
@@ -17,8 +16,6 @@ ActiveAdmin.register Timeslot do
     end
     column :title
     column(:display, &:to_s)
-    # column :starts_at
-    # column :ends_at
     column :schedulable
     actions
   end
@@ -32,6 +29,16 @@ ActiveAdmin.register Timeslot do
       row :ends_at
       row(:display, &:to_s)
       row :schedulable
+    end
+
+    panel "Sessions" do
+      table_for timeslot.sessions.order('sessions.attendances_count DESC') do
+        column :title do |session|
+          link_to session.title, admin_session_path(session)
+        end
+        column :presenters
+        column :room
+      end
     end
   end
 

--- a/app/admin/timeslots.rb
+++ b/app/admin/timeslots.rb
@@ -11,10 +11,9 @@ ActiveAdmin.register Timeslot do
   index do
     column :id
     column :event
-    column("Date") do |timeslot|
-      timeslot.starts_at.in_time_zone.strftime("%B %e, %Y")
+    column :title do |timeslot|
+      link_to timeslot.title, admin_event_timeslot_path(timeslot.event, timeslot)
     end
-    column :title
     column(:display, &:to_s)
     column :schedulable
     actions
@@ -32,13 +31,19 @@ ActiveAdmin.register Timeslot do
     end
 
     panel "Sessions" do
-      table_for timeslot.sessions.order('sessions.attendances_count DESC') do
-        column :title do |session|
-          link_to session.title, admin_session_path(session)
+      if timeslot.sessions.any?
+        table_for timeslot.sessions.order('sessions.attendances_count DESC') do
+          column :title do |session|
+            link_to session.title, admin_session_path(session)
+          end
+          column :presenters
+          column :room
+          column("Votes", &:attendances_count)
         end
-        column :presenters
-        column :room
-        column("Votes", &:attendances_count)
+      else
+        div do
+          "No sessions scheduled during this timeslot."
+        end
       end
     end
   end

--- a/app/admin/timeslots.rb
+++ b/app/admin/timeslots.rb
@@ -38,6 +38,7 @@ ActiveAdmin.register Timeslot do
         end
         column :presenters
         column :room
+        column("Votes", &:attendances_count)
       end
     end
   end

--- a/app/admin/timeslots.rb
+++ b/app/admin/timeslots.rb
@@ -6,6 +6,7 @@ ActiveAdmin.register Timeslot do
   permit_params :event_id, :starts_at, :ends_at, :schedulable, :title
   config.sort_order = 'starts_at_asc'
 
+  # don't allow delete
   actions :all, except: [:destroy]
 
   index do

--- a/app/admin/timeslots.rb
+++ b/app/admin/timeslots.rb
@@ -1,0 +1,48 @@
+ActiveAdmin.register Timeslot do
+  menu parent: "Events", label: "Timeslots"
+  config.filters = false
+
+  belongs_to :event
+
+  permit_params :event_id, :starts_at, :ends_at, :schedulable, :title
+  config.sort_order = 'starts_at_asc'
+
+  actions :all, except: [:destroy]
+
+  index do
+    column :id
+    column :event
+    column("Date") do |timeslot|
+      timeslot.starts_at.in_time_zone.strftime("%B %e, %Y")
+    end
+    column :title
+    column(:display, &:to_s)
+    # column :starts_at
+    # column :ends_at
+    column :schedulable
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :event
+      row :title
+      row :starts_at
+      row :ends_at
+      row(:display, &:to_s)
+      row :schedulable
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :event, as: :select, input_html: { disabled: true }
+      f.input :title
+      f.input :starts_at
+      f.input :ends_at
+      f.input :schedulable
+    end
+    f.actions
+  end
+end


### PR DESCRIPTION
This gets us closer to [feature parity with the legacy admin panel](https://github.com/minnestar/sessionizer/issues/321).

* Add `Settings` to admin panel
* Add `Timeslots` to admin panel (`belongs_to :event`)
* Add `Rooms` to admin panel (`belongs_to :event`)
* Update event info & links to make things easily navigable