### PR TITLE
Allow canceling sessions from admin panel

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -95,7 +95,7 @@ ActiveAdmin.register_page "Dashboard" do
         column :room, sortable: :room do |session|
           link_to session.room&.name, admin_event_room_path(session.event, session.room) if session.room
         end
-        column("Canceled", sortable: :canceled?, &:canceled?)
+        column("Canceled", sortable: :canceled_at, &:canceled?)
         column("Created", sortable: :created_at) do |session|
           session.created_at.strftime("%-m/%-d/%y")
         end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -132,16 +132,27 @@ ActiveAdmin.register Event do
       end
 
       sessions = event.sessions
+                     .with_canceled
                      .includes(:presenters, :attendances, :timeslot, :room)
                      .joins('LEFT JOIN rooms ON rooms.id = sessions.room_id')
                      .order(order_clause)
 
       table_for sessions, sortable: true do
         column :title, sortable: :title do |session|
-          link_to truncate(session.title, length: 80), admin_session_path(session)
+          (link_to(truncate(session.title, length: 80), admin_session_path(session)) +
+          (session.canceled? ? " (CANCELED)" : "")).html_safe
         end
         column :presenters, sortable: false do |session|
-          session.presenters.map { |presenter| link_to presenter.name, admin_participant_path(presenter) }.join(", ").html_safe
+          presenters = session.presenters
+          if presenters.size > 3
+            presenters = presenters.first(2)
+            presenter_links = presenters.map do |presenter|
+              link_to presenter.name, admin_participant_path(presenter)
+            end
+            [presenter_links, " and #{session.presenters.size - 2} others"].join(", ").html_safe
+          else
+            presenters.map { |presenter| link_to presenter.name, admin_participant_path(presenter) }.join(", ").html_safe
+          end
         end
         column("Votes", sortable: :attendances_count, &:attendances_count)
         column :timeslot, sortable: :timeslot_id do |session|
@@ -150,6 +161,7 @@ ActiveAdmin.register Event do
         column :room, sortable: :room do |session|
           link_to session.room&.name, admin_event_room_path(session.event, session.room) if session.room
         end
+        column("Canceled", sortable: :canceled?, &:canceled?)
         column("Created", sortable: :created_at) do |session|
           session.created_at.strftime("%-m/%-d/%y")
         end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -161,7 +161,7 @@ ActiveAdmin.register Event do
         column :room, sortable: :room do |session|
           link_to session.room&.name, admin_event_room_path(session.event, session.room) if session.room
         end
-        column("Canceled", sortable: :canceled?, &:canceled?)
+        column("Canceled", sortable: :canceled_at, &:canceled?)
         column("Created", sortable: :created_at) do |session|
           session.created_at.strftime("%-m/%-d/%y")
         end

--- a/app/admin/rooms.rb
+++ b/app/admin/rooms.rb
@@ -41,17 +41,19 @@ ActiveAdmin.register Room do
       row :schedulable
     end
 
-    panel "Sessions" do
-      if room.sessions.any?
-        table_for room.sessions.order('sessions.timeslot_id') do
+    panel "Sessions (#{room.sessions.with_canceled.count})" do
+      if room.sessions.with_canceled.any?
+        table_for room.sessions.with_canceled.order('sessions.timeslot_id') do
           column("Timeslot") do |session|
             link_to session.timeslot.to_s, admin_event_timeslot_path(session.event, session.timeslot)
         end
         column :title do |session|
-          link_to session.title, admin_session_path(session)
-        end
+          (link_to(session.title, admin_session_path(session)) +
+          (session.canceled? ? " (CANCELED)" : "")).html_safe
+          end
         column :presenters
-          column("Votes", &:attendances_count)
+        column("Votes", &:attendances_count)
+        column("Canceled", &:canceled?)
         end
       else
         div do

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -96,7 +96,9 @@ ActiveAdmin.register Session do
       row :title
       row :participant
       row :presenters
-      row :description
+      row :description do |session|
+        markdown session.description
+      end
       row :level
       row :categories
       row("Votes") do |session|
@@ -105,8 +107,8 @@ ActiveAdmin.register Session do
       row :timeslot
       row :room
       row :manually_scheduled
-      row :canceled?
       row :canceled_at
+      row :canceled?
       row :created_at
       row :updated_at
     end

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -62,7 +62,11 @@ ActiveAdmin.register Session do
   end
 
   action_item :uncancel, only: :show do
-    link_to('Uncancel Session', uncancel_admin_session_path(resource), method: :post) if resource.canceled?
+    link_to(
+      'Uncancel Session',
+      uncancel_admin_session_path(resource),
+      method: :post
+    ) if resource.canceled? && resource.event_id == Event.current_event.id
   end
 
   index do
@@ -82,7 +86,7 @@ ActiveAdmin.register Session do
     column("Votes", sortable: :attendances_count, &:attendances_count)
     column :timeslot, sortable: :timeslot
     column :room, sortable: :room
-    column("Canceled", &:canceled?)
+    column("Canceled", sortable: :canceled_at, &:canceled?)
     column("Created", sortable: :created_at) do |session|
       session.created_at.strftime("%-m/%-d/%y")
     end

--- a/app/admin/sessions.rb
+++ b/app/admin/sessions.rb
@@ -7,8 +7,8 @@ ActiveAdmin.register Session do
     end
   end
 
-  scope :all
-  scope :active, default: true
+  scope :all, default: true
+  scope :active
   scope :canceled
 
   permit_params(

--- a/app/admin/timeslots.rb
+++ b/app/admin/timeslots.rb
@@ -40,15 +40,17 @@ ActiveAdmin.register Timeslot do
       row :schedulable
     end
 
-    panel "Sessions" do
-      if timeslot.sessions.any?
-        table_for timeslot.sessions.order('sessions.attendances_count DESC') do
+    panel "Sessions (#{timeslot.sessions.with_canceled.count})" do
+      if timeslot.sessions.with_canceled.any?
+        table_for timeslot.sessions.with_canceled.order('sessions.attendances_count DESC') do
           column :title do |session|
-            link_to session.title, admin_session_path(session)
+            (link_to(session.title, admin_session_path(session)) +
+            (session.canceled? ? " (CANCELED)" : "")).html_safe
           end
           column :presenters
           column :room
           column("Votes", &:attendances_count)
+          column("Canceled", &:canceled?)
         end
       else
         div do

--- a/db/migrate/20250330143647_add_counter_caches_to_events.rb
+++ b/db/migrate/20250330143647_add_counter_caches_to_events.rb
@@ -7,7 +7,25 @@ class AddCounterCachesToEvents < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         say_with_time "Updating Event counter caches..." do
-          Event.find_each { |event| Event.reset_counters(event.id, :sessions, :rooms, :timeslots) }
+          # Use SQL directly to avoid model scopes
+          execute <<-SQL
+            UPDATE events
+            SET sessions_count = (
+              SELECT COUNT(*)
+              FROM sessions
+              WHERE sessions.event_id = events.id
+            ),
+            rooms_count = (
+              SELECT COUNT(*)
+              FROM rooms
+              WHERE rooms.event_id = events.id
+            ),
+            timeslots_count = (
+              SELECT COUNT(*)
+              FROM timeslots
+              WHERE timeslots.event_id = events.id
+            )
+          SQL
         end
       end
     end

--- a/db/migrate/20250330164250_add_counter_caches_to_sessions.rb
+++ b/db/migrate/20250330164250_add_counter_caches_to_sessions.rb
@@ -5,7 +5,15 @@ class AddCounterCachesToSessions < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         say_with_time "Updating Session counter caches..." do
-          Session.find_each { |session| Session.reset_counters(session.id, :attendances) }
+          # Use SQL directly to avoid model scopes
+          execute <<-SQL
+            UPDATE sessions
+            SET attendances_count = (
+              SELECT COUNT(*)
+              FROM attendances
+              WHERE attendances.session_id = sessions.id
+            )
+          SQL
         end
       end
     end

--- a/db/migrate/20250412161057_add_canceled_at_to_sessions.rb
+++ b/db/migrate/20250412161057_add_canceled_at_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddCanceledAtToSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :sessions, :canceled_at, :datetime
+  end
+end 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_12_161056) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_12_161057) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -139,6 +139,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_12_161056) do
     t.boolean "manually_scheduled", default: false, null: false
     t.integer "manual_attendance_estimate"
     t.integer "attendances_count", default: 0
+    t.datetime "canceled_at"
     t.index ["level_id"], name: "index_sessions_on_level_id"
   end
 


### PR DESCRIPTION
This makes it possible for admins to cancel sessions from the admin panel, without hard-deleting or soft-deleting (by entering a negative `event_id`).

**Screenshots**

<img width="1512" alt="Sessionizer admin sessions cancel show 1" src="https://github.com/user-attachments/assets/5af10148-3b67-444f-beb1-23fe84136028" />

<img width="1512" alt="Sessionizer admin sessions cancel show 2" src="https://github.com/user-attachments/assets/fe7cbd47-dad9-47cd-8445-042122a36055" />


<img width="1209" alt="Sessionizer admin sessions cancel index 1" src="https://github.com/user-attachments/assets/e85747c6-a21f-48e5-9d18-1ab0fc2ceccb" />


**Demo**


https://github.com/user-attachments/assets/fbe64c5d-b723-4bc5-a54a-24d16930b11a


