### PR TITLE
Added GitHub Workflows status badge, removed Scrutinizer badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sessionizer is a tool for managing session registration for unconferences. It was written for [Minnebar](http://minnestar.org/minnebar/), an unconference in Minnesota and one of the largest BarCamps in the world.
 
-[![Scrutinizer](http://img.shields.io/scrutinizer/g/minnestar/sessionizer.svg)](https://scrutinizer-ci.com/g/minnestar/sessionizer/)
+[![CI](https://github.com/minnestar/sessionizer/actions/workflows/ci.yml/badge.svg)](https://github.com/minnestar/sessionizer/actions/workflows/ci.yml)
 
 ## Features
 


### PR DESCRIPTION
This repository switched to GitHub Workflows for continuous integration, but the status badge has not been added.  So this pull request adds it.

The old Scrutinizer CI hasn't worked for this repository in a long time.  Unless there are plans to pay for it and start using it again, there is no good reason to keep its status badge.