### PR TITLE
Rename verify CI step; Prevent duplicate runs on PR commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 
-on: [push, pull_request ]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-  verify:
+  test:
     runs-on: ubuntu-latest
 
     services:
@@ -18,19 +21,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Linux libraries
         run: sudo apt-get install -y libpq-dev
-      
+
       - name: Set up Ruby and run bundle install
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4.1
           bundler-cache: true
-      
+
       - name: Show Ruby version
         run: ruby -v
-      
+
       - name: Prepare database and run tests
         env:
           CI: github


### PR DESCRIPTION
- Rename `verify` CI step to `test`
- Prevent duplicate CI runs for PRs