### PR TITLE
Coc as a timestamp

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -4,6 +4,7 @@ class ParticipantsController < ApplicationController
   respond_to :html
   load_resource except: :confirm_email
   before_action :verify_owner, :only => [:edit, :update]
+  before_action :coc_agreement_param_as_timestamp, only: [:create, :update]
 
   def index
     respond_to do |format|
@@ -40,7 +41,6 @@ class ParticipantsController < ApplicationController
     end
 
     if @participant.update(new_params)
-      create_code_of_conduct_agreement_if_not_exists!
       flash[:notice] = "Profile updated successfully."
       redirect_to participant_path(@participant)
     else
@@ -52,22 +52,12 @@ class ParticipantsController < ApplicationController
   def create
     @participant.attributes = participant_params.except(:code_of_conduct_agreement)
     if @participant.save
-      create_code_of_conduct_agreement_if_not_exists!
       @participant.deliver_email_confirmation_instructions!
       flash[:notice] = "Thanks for registering an account. Please check your email to confirm your account."
       redirect_to root_path
     else
       flash[:error] = "There was a problem creating your account."
       render :new
-    end
-  end
-
-  def create_code_of_conduct_agreement_if_not_exists!
-    if participant_params[:code_of_conduct_agreement] == '1' && @participant.signed_code_of_conduct_for_current_event? == false
-      CodeOfConductAgreement.create!({
-        participant_id: @participant.id,
-        event_id: Event.current_event.id,
-      })
     end
   end
 
@@ -95,11 +85,18 @@ class ParticipantsController < ApplicationController
       :name, :email, :password,
       :bio,
       :code_of_conduct_agreement,
-      :contact_details
+      :contact_details, :coc_agreed_at
     )
   end
 
   def verify_owner
     redirect_to participant_path(@participant) if @participant != current_participant
+  end
+
+  def coc_agreement_param_as_timestamp
+    if params[:participant][:code_of_conduct_agreement] == '1'
+      params[:participant] ||= {}
+      params[:participant][:coc_agreed_at] = Time.current
+    end
   end
 end

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -95,7 +95,6 @@ class ParticipantsController < ApplicationController
 
   def coc_agreement_param_as_timestamp
     if params[:participant][:code_of_conduct_agreement] == '1'
-      params[:participant] ||= {}
       params[:participant][:coc_agreed_at] = Time.current
     end
   end

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -20,7 +20,7 @@ class PresentationsController < ApplicationController
         flash[:error] = "Sorry, no presenter #{participant_params[:name] ? "matching '#{participant_params[:name]}' " : "" }was found. Please try again."
         redirect_to session_presentations_path(@session)
         return
-      elsif participant.signed_code_of_conduct_for_current_event? == false
+      elsif participant.signed_code_of_conduct? == false
         flash[:error] = "Sorry, #{participant.name} hasn't signed the current Code of Conduct."
         redirect_to session_presentations_path(@session)
         return

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -78,7 +78,7 @@ class SessionsController < ApplicationController
   end
 
   def create_code_of_conduct_agreement_if_not_exists!
-    if session_params[:code_of_conduct_agreement] == '1' && !@session.participant.signed_code_of_conduct?
+    if session_params[:code_of_conduct_agreement] == '1' && !current_participant.signed_code_of_conduct?
       current_participant.update!(coc_agreed_at: Time.current)
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -78,11 +78,8 @@ class SessionsController < ApplicationController
   end
 
   def create_code_of_conduct_agreement_if_not_exists!
-    if session_params[:code_of_conduct_agreement] == '1' && @session.participant.signed_code_of_conduct_for_current_event? == false
-      CodeOfConductAgreement.create!({
-        participant_id: @session.participant.id,
-        event_id: Event.current_event.id,
-      })
+    if session_params[:code_of_conduct_agreement] == '1' && !@session.participant.signed_code_of_conduct_for_current_event?
+      current_participant.update!(coc_agreed_at: Time.current)
     end
   end
 
@@ -139,5 +136,4 @@ private
       .order('created_at desc')
       .distinct
   end
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -78,7 +78,7 @@ class SessionsController < ApplicationController
   end
 
   def create_code_of_conduct_agreement_if_not_exists!
-    if session_params[:code_of_conduct_agreement] == '1' && !@session.participant.signed_code_of_conduct_for_current_event?
+    if session_params[:code_of_conduct_agreement] == '1' && !@session.participant.signed_code_of_conduct?
       current_participant.update!(coc_agreed_at: Time.current)
     end
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -82,12 +82,7 @@ class Participant < ActiveRecord::Base
   end
 
   def signed_code_of_conduct_for_current_event?
-    return false unless Event.current_event
-
-    CodeOfConductAgreement.where({
-      participant_id: id,
-      event_id: Event.current_event.id,
-    }).exists?
+    coc_agreed_at != nil
   end
 
   def attending_session?(session)

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -81,7 +81,7 @@ class Participant < ActiveRecord::Base
     Notifier.password_reset_instructions(self).deliver_now!
   end
 
-  def signed_code_of_conduct_for_current_event?
+  def signed_code_of_conduct?
     coc_agreed_at.present?
   end
 

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -82,7 +82,7 @@ class Participant < ActiveRecord::Base
   end
 
   def signed_code_of_conduct_for_current_event?
-    coc_agreed_at != nil
+    coc_agreed_at.present?
   end
 
   def attending_session?(session)

--- a/app/views/participants/edit.html.erb
+++ b/app/views/participants/edit.html.erb
@@ -28,8 +28,8 @@
         as: :boolean,
         label: ("I agree to the #{link_to 'Code of Conduct', 'https://minnestar.org/code-of-conduct'} governing this event.").html_safe,
         input_html: {
-          checked: @participant.signed_code_of_conduct_for_current_event?,
-          disabled: @participant.signed_code_of_conduct_for_current_event?
+          checked: @participant.signed_code_of_conduct?,
+          disabled: @participant.signed_code_of_conduct?
         }
     %>
   <% end %>

--- a/app/views/participants/new.html.erb
+++ b/app/views/participants/new.html.erb
@@ -17,8 +17,8 @@
         required: true, # this only adds an asterisk to the label, it doesn't make the field required
         label: ("I agree to the #{link_to 'Code of Conduct', 'https://minnestar.org/code-of-conduct'} governing this event.").html_safe,
         input_html: {
-          checked: @participant.signed_code_of_conduct_for_current_event?,
-          disabled: @participant.signed_code_of_conduct_for_current_event?
+          checked: @participant.signed_code_of_conduct?,
+          disabled: @participant.signed_code_of_conduct?
         }
     %>
  <% end %>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -17,8 +17,8 @@
         required: true,
         label: ("I agree to the #{link_to 'Code of Conduct', 'https://minnestar.org/code-of-conduct'} governing this event.").html_safe,
         input_html: {
-          checked: current_participant.signed_code_of_conduct_for_current_event?,
-          disabled: current_participant.signed_code_of_conduct_for_current_event?
+          checked: current_participant.signed_code_of_conduct?,
+          disabled: current_participant.signed_code_of_conduct?
         }
     %>
   <% end %>

--- a/db/migrate/20260520012517_add_coc_agreed_at_to_participants.rb
+++ b/db/migrate/20260520012517_add_coc_agreed_at_to_participants.rb
@@ -1,0 +1,5 @@
+class AddCocAgreedAtToParticipants < ActiveRecord::Migration[7.2]
+  def change
+    add_column :participants, :coc_agreed_at, :datetime
+  end
+end

--- a/db/migrate/20260526173525_backfill_coc_agreed_at.rb
+++ b/db/migrate/20260526173525_backfill_coc_agreed_at.rb
@@ -1,15 +1,10 @@
 class BackfillCocAgreedAt < ActiveRecord::Migration[7.2]
   def up
-    ActiveRecord::Base.connection.execute(<<~SQL)
-      UPDATE participants
-      SET coc_agreed_at = coc.created_at
-      FROM (
-        SELECT DISTINCT ON (participant_id) participant_id, created_at
-        FROM code_of_conduct_agreements
-      ) AS coc
-      WHERE participants.id = coc.participant_id
-      AND participants.coc_agreed_at IS NULL
-    SQL
+     Participant.where(coc_agreed_at: nil).find_each do |participant|
+       aggreement = CodeOfConductAgreement.where(participant_id: participant.id)
+         .order(created_at: :desc).first
+      participant.update_column(:coc_agreed_at, aggreement.created_at) if aggreement
+    end
   end
 
   def down

--- a/db/migrate/20260526173525_backfill_coc_agreed_at.rb
+++ b/db/migrate/20260526173525_backfill_coc_agreed_at.rb
@@ -1,7 +1,5 @@
-namespace :backfill do
-
-  desc 'backfill coc_agreed_at for participants who have already accepted'
-  task coc_agreed_at: :environment do
+class BackfillCocAgreedAt < ActiveRecord::Migration[7.2]
+  def up
     ActiveRecord::Base.connection.execute(<<~SQL)
       UPDATE participants
       SET coc_agreed_at = coc.created_at
@@ -12,5 +10,9 @@ namespace :backfill do
       WHERE participants.id = coc.participant_id
       AND participants.coc_agreed_at IS NULL
     SQL
+  end
+
+  def down
+    Participant.update_all(coc_agreed_at: nil)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_20_012517) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_26_173525) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_22_192507) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_20_012517) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -114,6 +114,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_22_192507) do
     t.datetime "email_confirmed_at", precision: nil
     t.integer "presentations_count", default: 0
     t.integer "attendances_count", default: 0
+    t.datetime "coc_agreed_at"
     t.index ["email"], name: "index_participants_on_email", unique: true
     t.index ["perishable_token"], name: "index_participants_on_perishable_token"
   end

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -517,6 +517,7 @@ namespace :app do
       participant.email = FFaker::Internet.safe_email
       participant.password = 'password'
       participant.bio = FFaker::Lorem.paragraph if [true, false].sample
+      participant.coc_agreed_at = Time.current
       participant.save!
       progress.increment
     end

--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -1,0 +1,16 @@
+namespace :backfill do
+
+  desc 'backfill coc_agreed_at for participants who have already accepted'
+  task coc_agreed_at: :environment do
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      UPDATE participants
+      SET coc_agreed_at = coc.created_at
+      FROM (
+        SELECT DISTINCT ON (participant_id) participant_id, created_at
+        FROM code_of_conduct_agreements
+      ) AS coc
+      WHERE participants.id = coc.participant_id
+      AND participants.coc_agreed_at IS NULL
+    SQL
+  end
+end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -45,6 +45,25 @@ describe ParticipantsController do
       expect(response).to render_template(:new)
       expect(flash[:error]).to eq "There was a problem creating your account."
     end
+
+    it "does not set coc_agreed_at on the participant when the user has not signed the code of conduct" do
+      post :create, params: { participant:  { name: 'Alan Turing',
+                                              email: 'tapewriter@example.org',
+                                              password: 'infinite-memory',
+                                              code_of_conduct_agreement: '0'
+                                            }
+                            }
+      expect(Participant.find_by(email: 'tapewriter@example.org').coc_agreed_at).to be_nil
+    end
+    it "sets coc_agreed_at on the participant when the user has signed the code of conduct" do
+      post :create, params: { participant:  { name: 'Alan Turing',
+                                              email: 'tapewriter@example.org',
+                                              password: 'infinite-memory',
+                                              code_of_conduct_agreement: '1'
+                                            }
+                            }
+      expect(Participant.find_by(email: 'tapewriter@example.org').coc_agreed_at).not_to be_nil
+    end
   end
 
   describe "#show" do
@@ -136,6 +155,14 @@ describe ParticipantsController do
         put :update, params: {id: joe, participant: { name: 'schmoe, joe' }}
         expect(response).to redirect_to participant_path(joe)
         expect(joe.reload.name).to eq 'schmoe, joe'
+      end
+      it "does not set coc_agreed_at on the participant when the user has not signed the code of conduct" do
+        put :update, params:  { id: joe,  participant:  { name: 'Alan Turing', code_of_conduct_agreement: '0' } }
+        expect(joe.reload.coc_agreed_at).to be_nil
+      end
+      it "sets coc_agreed_at on the participant when the user has signed the code of conduct" do
+        put :update, params:  { id: joe,  participant:  { code_of_conduct_agreement: '1' } }
+        expect(joe.reload.coc_agreed_at).not_to be_nil
       end
 
       describe "more attributes are not required" do

--- a/spec/controllers/presentations_controller_spec.rb
+++ b/spec/controllers/presentations_controller_spec.rb
@@ -20,10 +20,7 @@ describe PresentationsController do
 
     context "when the user is found by id" do
       it "should be successful when the user has signed the code of conduct" do
-        CodeOfConductAgreement.create!({
-          participant_id: participant.id,
-          event_id: Event.current_event.id,
-        })
+        participant.update!(coc_agreed_at: Time.current)
 
         expect {
           post :create, params: { session_id: session, id: participant.id }
@@ -41,10 +38,7 @@ describe PresentationsController do
 
     context "when the user is found by name" do
       it "should be successful when the user has signed the code of conduct" do
-        CodeOfConductAgreement.create!({
-          participant_id: participant.id,
-          event_id: Event.current_event.id,
-        })
+        participant.update!(coc_agreed_at: Time.current)
 
         expect {
           post :create, params: { session_id: session, name: participant.name }

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -138,6 +138,29 @@ describe SessionsController do
           expect(assigns[:session].category_ids).to include category.id
           expect(flash[:notice]).to eq "Thanks for adding your session."
         end
+        it "should sign code of conduct if param is present" do
+          expect {
+            post :create, params: { session:  { title: "new title",
+                                                description: "new description",
+                                                category_ids: [category.id],
+                                                level_id: "2",
+                                                code_of_conduct_agreement:  "1",
+                                              }
+                                  }
+          }.to change { Session.count }.by(1)
+          expect(user.reload.coc_agreed_at).not_to be_nil
+        end
+        it "should not sign code of conduct if param is not present" do
+          expect {
+            post :create, params: { session:  { title: "new title",
+                                                description: "new description",
+                                                category_ids: [category.id],
+                                                level_id: "2",
+                                              }
+                                  }
+          }.to change { Session.count }.by(1)
+          expect(user.reload.coc_agreed_at).to be_nil
+        end
       end
 
       context "with invalid values" do


### PR DESCRIPTION
Top level TL;DR
========

Replace CodeOfConductAgreement records with a coc_agreed_at timestamp

Simplifies code of conduct tracking by storing agreement as a single timestamp on participants rather than a separate join table record
per event.

  Modifications
======

  - Add `coc_agreed_at` datetime column to participants
  - `signed_code_of_conduct_for_current_event?` now checks `coc_agreed_at` presence instead of querying `code_of_conduct_agreements`
  - `ParticipantsController` converts the code_of_conduct_agreement checkbox param to a `coc_agreed_at` timestamp before saving
  - `SessionsController` sets `coc_agreed_at` on the participant instead of creating a `CodeOfConductAgreement` record
  - Backfill rake task (`backfill:coc_agreed_at`) populates `coc_agreed_at` from existing `code_of_conduct_agreements` records
  - Updated tests and faker seed data to use the new field